### PR TITLE
Add a check for `AudioWorkletNode` when sniffing AudioWorklet features

### DIFF
--- a/audio-worklet/lib/audio-worklet-helper.js
+++ b/audio-worklet/lib/audio-worklet-helper.js
@@ -15,12 +15,9 @@ const AudioWorkletHelper = (() => {
   let eReporterDiv_;
 
   function isAvailable_() {
-    let isAvailable =
-        window.audioWorklet &&
-        typeof window.audioWorklet.addModule === 'function' &&
-        window.AudioWorkletNode;
-
-    return isAvailable;
+    return window.audioWorklet &&
+           typeof window.audioWorklet.addModule === 'function' &&
+           window.AudioWorkletNode;
   }
 
   function initializeHelper_() {

--- a/audio-worklet/lib/audio-worklet-helper.js
+++ b/audio-worklet/lib/audio-worklet-helper.js
@@ -15,8 +15,12 @@ const AudioWorkletHelper = (() => {
   let eReporterDiv_;
 
   function isAvailable_() {
-    return window.audioWorklet &&
-        typeof window.audioWorklet.addModule === 'function';
+    let isAvailable =
+        window.audioWorklet &&
+        typeof window.audioWorklet.addModule === 'function' &&
+        window.AudioWorkletNode;
+
+    return isAvailable;
   }
 
   function initializeHelper_() {


### PR DESCRIPTION
Fixes #123.