### PR TITLE
Add a link for templated bug report

### DIFF
--- a/audio-worklet/index.html
+++ b/audio-worklet/index.html
@@ -15,11 +15,11 @@
       </h1>
       <p>
         <a href=
-        "https://webaudio.github.io/web-audio-api/#AudioWorklet">AudioWorklet</a>
-        is currently available on Chrome behind the experimental flag. Use the
-        following <a href=
-        "https://www.chromium.org/developers/how-tos/run-chromium-with-flags">command
-        line option</a> to activate the feature.
+        "https://webaudio.github.io/web-audio-api/#AudioWorklet">AudioWorklet
+        </a> is currently available on Chrome Canary behind the experimental
+        flag. Use the following <a href=
+        "https://www.chromium.org/developers/how-tos/run-chromium-with-flags">
+        command line option</a> to activate the feature.
       </p>
       <p>
         <code class="flag">--enable-blink-features=Worklet,AudioWorklet</code>
@@ -57,7 +57,8 @@
     </section>
     <section>
       <h3>Found something broken?</h3>
-      <p><a target="_blank" href="https://bugs.chromium.org/p/chromium/issues/entry?template=Defect%20report%20from%20user&summary=[audioworklet]%20&components=Blink%3EWebAudio">
+      <p><a target="_blank" href=
+        "https://bugs.chromium.org/p/chromium/issues/entry?template=Defect%20report%20from%20user&summary=[audioworklet]%20&components=Blink%3EWebAudio">
         Report it via crbug.</p>
     </section>
   </body>

--- a/audio-worklet/index.html
+++ b/audio-worklet/index.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="../resources/base.css">
   </head>
   <body>
-    <a href="../index.html" class="link-small">« WebAudio sample home</a>
+    <a href="../index.html" class="link-small">« Chrome WebAudio Sample Home</a>
     <section>
       <h1>
         AudioWorklet
@@ -54,6 +54,11 @@
           <a href="basic/one-pole.html">One-Pole filter</a>
         </li>
       </ul>
+    </section>
+    <section>
+      <h3>Found something broken?</h3>
+      <p><a target="_blank" href="https://bugs.chromium.org/p/chromium/issues/entry?template=Defect%20report%20from%20user&summary=[audioworklet]%20&components=Blink%3EWebAudio">
+        Report it via crbug.</p>
     </section>
   </body>
 </html>


### PR DESCRIPTION
The link is now exposed to social media, so it is helpful get some early feedback through the demo page.