### PR TITLE
New AudioWorklet project landing page

### DIFF
--- a/audio-worklet/index.html
+++ b/audio-worklet/index.html
@@ -6,7 +6,7 @@
       AudioWorklet | Chrome WebAudio Samples
     </title>
     <link rel="stylesheet" href=
-    "//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+    "//fonts.googleapis.com/css?family=Roboto:400,400italic,700,700italic">
     <link rel="stylesheet" href=
     "//cdn.rawgit.com/necolas/normalize.css/master/normalize.css">
     <link rel="stylesheet" href=

--- a/audio-worklet/index.html
+++ b/audio-worklet/index.html
@@ -5,68 +5,137 @@
     <title>
       AudioWorklet | Chrome WebAudio Samples
     </title>
-    <link rel="stylesheet" href="../resources/base.css">
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+    <link rel="stylesheet" href="//cdn.rawgit.com/necolas/normalize.css/master/normalize.css">
+    <link rel="stylesheet" href="//cdn.rawgit.com/milligram/milligram/master/dist/milligram.min.css">
+    <link rel="stylesheet" href="../resources/base-v2.css">
   </head>
   <body>
-    <a href="../index.html" class="link-small">« Chrome WebAudio Sample Home</a>
-    <section>
-      <h1>
-        AudioWorklet
-      </h1>
-      <p>
-        <a href=
-        "https://webaudio.github.io/web-audio-api/#AudioWorklet">AudioWorklet
-        </a> is currently available on Chrome Canary behind the experimental
-        flag. Use the following <a href=
-        "https://www.chromium.org/developers/how-tos/run-chromium-with-flags">
-        command line option</a> to activate the feature.
-      </p>
-      <p>
-        <code class="flag">--enable-blink-features=Worklet,AudioWorklet</code>
-      </p>
-      <p>
-        Or you can enable Experimental Web Platform Features in Chrome's flag
-        setting. Note that this setting enables all the experimental features
-        in browser. Copy and paste the following URL in Chrome.
-      </p>
-      <p>
-        <code class=
-        "flag">chrome://flags/#enable-experimental-web-platform-features</code>
-      </p>
+
+    <div class="container">
+
+    <!-- Feature indicator -->
+    <div class="float-right">
+      <div class="worklet-status">AudioWorklet Ready</div>
+    </div>
+
+    <section class="nav-bar">
+      <a href="../index.html"><span>Chrome WebAudio Samples</span></a>
+      <span class="nav-divider">|</span>
+      <span>AudioWorklet</span>
     </section>
-    <section>
-      <h2>
-        Basic Demos
-      </h2>
-      <ul>
-        <li>
-          <a href="basic/hello-audio-worklet.html">"Hello AudioWorklet!"</a>
-        </li>
-        <li>
-          <a href="basic/noise-audio-param.html">Noise with AudioParam
-          Modulation</a>
-        </li>
-        <li>
-          <a href="basic/bit-crusher.html">BitCrusher with AudioParam
-          Automation</a>
-        </li>
-        <li>
-          <a href="basic/one-pole.html">One-Pole filter</a>
-        </li>
-        <li>
-          <a href="basic/message-port.html">MessagePort with AudioWorklet</a>
-        </li>
-        <li>
-          <a href="basic/event-processor-state.html">Event and
-          AudioWorkletProcessorState</a>
-        </li>
-      </ul>
+
+    <!-- Header and instruction -->
+    <section class="header">
+      <h1>AudioWorklet</h1>
+      <p><a href="https://webaudio.github.io/web-audio-api/#AudioWorklet" target="_blank">AudioWorklet</a> is currently available on <strong>Chrome Beta</strong> behind the experimental flag or <a href="https://docs.google.com/forms/d/e/1FAIpQLSfO0_ptFl8r8G0UFhT0xhV17eabG-erUWBDiKSRDTqEZ_9ULQ/viewform">Origin Trials</a>. To activate the feature locally, use the following <a href="https://www.chromium.org/developers/how-tos/run-chromium-with-flags">command line option</a>.</p>
+      <pre><code>--enable-blink-features=Worklet,AudioWorklet</code></pre>
+      <p>Alternatively, you can enable Experimental Web Platform Features in Chrome's flag setting. Note that this setting enables all the experimental features in browser. Copy and paste the following URL in Chrome, enable the feature and relaunch the browser.
+      </p>
+      <pre><code>chrome://flags/#enable-experimental-web-platform-features</code></pre>
+      <p>If the status indicator on the top-right corner of this page is not green, it means either your browser does not support AudioWorklet or you need to follow the instruction above to activate the feature.</p>
     </section>
-    <section>
-      <h3>Found something broken?</h3>
-      <p><a target="_blank" href=
-        "https://bugs.chromium.org/p/chromium/issues/entry?template=Defect%20report%20from%20user&summary=[audioworklet]%20&components=Blink%3EWebAudio">
-        Report it via crbug.</p>
-    </section>
+
+    <!-- Contents -->
+    <section class="content">
+
+      <h2>Basic Demos</h2>
+      <div class="row">
+        <div class="column">
+          <div class="demo-item">
+            <a href="basic/hello-audio-worklet.html"><h4>Hello AudioWorklet!</h4></a>
+            <p>A simple AudioWorkletNode that bypasses the incoming audio stream to its output.</p>
+          </div>
+        </div>
+        <div class="column">
+          <div class="demo-item">
+            <a href="basic/noise-audio-param.html"><h4>Noise with AudioParam Modulation</h4></a>
+            <p>A simple noise generator with user-defined 'gain' AudioParam modulated by an OscillatorNode.</p>
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="column">
+          <div class="demo-item">
+            <a href="basic/bit-crusher.html"><h4>BitCrusher with AudioParam Automation</h4></a>
+            <p>A BitCrusher example from the specification, but modified to demonstrate AudioParam automations</p>
+          </div>
+        </div>
+        <div class="column">
+          <div class="demo-item">
+            <a href="basic/one-pole.html"><h4>One-Pole Filter</h4></a>
+            <p>A one-pole filter implementation with AudioWorkletNode.</p>
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="column">
+          <div class="demo-item">
+            <a href="basic/message-port.html"><h4>MessagePort with AudioWorklet</h4></a>
+            <p>Demonstrates basic bi-directional communication between AudioWorkletNode and AudioWorkletProcessor.</p>
+          </div>
+        </div>
+        <div class="column">
+          <div class="demo-item">
+            <a href="basic/event-processor-state.html"><h4>Event and AudioWorkletProcessorState</h4></a>
+            <p>A simple demonstration of AudioWorkletProcessorState and how to catch processorstatechange event.</p>
+          </div>
+        </div>
+      </div>
+
+      <br><br>
+
+      <h2>Resources</h2>
+      <div class="row">
+        <div class="column">
+          <div class="demo-item">
+            <a href="https://goo.gl/R2zWtR"><h4>Talk: AudioWorklet - What, Why and How</h4></a>
+            <p>An in-depth presentation about what the new AudioWorklet is, why it matters for Web Audio, and how it works.</p>
+          </div>
+        </div>
+        <div class="column">
+          <div class="demo-item">
+            <a href="https://goo.gl/5c5LPD"><h4>Slides: AudioWorklet - What, Why and How</h4></a>
+            <p>The slide deck for the presentation.</p>
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="column">
+          <div class="demo-item">
+            <a href="https://webaudio.github.io/web-audio-api/#AudioWorklet"><h4>Web Audio API: AudioWorklet</h4></a>
+            <p>AudioWorklet section in Web Audio API specification.</p>
+          </div>
+        </div>
+        <div class="column">
+          <div class="demo-item">
+            <a href="https://github.com/WebAudio/web-audio-api/issues?q=is%3Aissue+audioworklet"><h4>Web Audio API discussions on AudioWorklet</h4></a>
+            <p>A set of discussions on AudioWorklet API design.</p>
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="column">
+          <div class="demo-item">
+            <a href="#"><h4>Google Developer Blog Post: AudioWorklet</h4></a>
+            <p>An introductory article on AudioWorklet from Google Developer Portal.</p>
+          </div>
+        </div>
+        <div class="column">
+          <div class="demo-item">
+          </div>
+        </div>
+      </div>
+  </section>
+
+  <!-- Footer -->
+  <section class="footer">
+    <a target="_blank" href=
+        "https://bugs.chromium.org/p/chromium/issues/entry?template=Defect%20report%20from%20user&summary=[audioworklet]%20&components=Blink%3EWebAudio">Found something broken?</a>
+    <br><br>
+    <p>Chrome &#9829; WebAudio</p>
+  </section>
+
+</div>
   </body>
 </html>

--- a/audio-worklet/index.html
+++ b/audio-worklet/index.html
@@ -16,8 +16,8 @@
   <body>
     <div class="container">
       <div class="float-right">
-        <div class="worklet-status">
-          AudioWorklet Ready
+        <div id="worklet-indicator" class="worklet-status-pending">
+          Checking...
         </div>
       </div>
       <section class="nav-bar">
@@ -45,8 +45,7 @@
           experimental features in browser. Copy and paste the following URL in
           Chrome, enable the feature and relaunch the browser.
         </p>
-        <pre><code>chrome://flags/#enable-experimental-web-platform-features
-        </code></pre>
+        <pre><code>chrome://flags/#enable-experimental-web-platform-features</code></pre>
         <p>
           If the status indicator on the top-right corner of this page is not
           green, it means either your browser does not support AudioWorklet or
@@ -215,5 +214,28 @@
         </p>
       </section>
     </div>
+
+    <script src="lib/audio-worklet-helper.js"></script>
+    <script>
+      (function() {
+        const indicator_div = document.querySelector('#worklet-indicator');
+        if (AudioWorkletHelper.isAvailable()) {
+          indicator_div.textContent = 'AudioWorklet Ready';
+          indicator_div.className = 'worklet-status-found';
+        } else {
+          indicator_div.textContent = 'No AudioWorklet';
+          indicator_div.className = 'worklet-status-missing';
+        }
+      })();
+    </script>
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+      ga('create', 'UA-57132539-4', 'auto');
+      ga('send', 'pageview');
+    </script>
+
   </body>
 </html>

--- a/audio-worklet/index.html
+++ b/audio-worklet/index.html
@@ -45,8 +45,8 @@
           experimental features in browser. Copy and paste the following URL in
           Chrome, enable the feature and relaunch the browser.
         </p>
-        <pre>
-        <code>chrome://flags/#enable-experimental-web-platform-features</code></pre>
+        <pre><code>chrome://flags/#enable-experimental-web-platform-features
+        </code></pre>
         <p>
           If the status indicator on the top-right corner of this page is not
           green, it means either your browser does not support AudioWorklet or

--- a/audio-worklet/index.html
+++ b/audio-worklet/index.html
@@ -5,137 +5,215 @@
     <title>
       AudioWorklet | Chrome WebAudio Samples
     </title>
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-    <link rel="stylesheet" href="//cdn.rawgit.com/necolas/normalize.css/master/normalize.css">
-    <link rel="stylesheet" href="//cdn.rawgit.com/milligram/milligram/master/dist/milligram.min.css">
+    <link rel="stylesheet" href=
+    "//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+    <link rel="stylesheet" href=
+    "//cdn.rawgit.com/necolas/normalize.css/master/normalize.css">
+    <link rel="stylesheet" href=
+    "//cdn.rawgit.com/milligram/milligram/master/dist/milligram.min.css">
     <link rel="stylesheet" href="../resources/base-v2.css">
   </head>
   <body>
-
     <div class="container">
-
-    <!-- Feature indicator -->
-    <div class="float-right">
-      <div class="worklet-status">AudioWorklet Ready</div>
+      <div class="float-right">
+        <div class="worklet-status">
+          AudioWorklet Ready
+        </div>
+      </div>
+      <section class="nav-bar">
+        <a href="../index.html"><span>Chrome WebAudio Samples</span></a>
+        <span class="nav-divider">|</span> <span>AudioWorklet</span>
+      </section>
+      <section class="header">
+        <h1>
+          AudioWorklet
+        </h1>
+        <p>
+          <a href="https://webaudio.github.io/web-audio-api/#AudioWorklet"
+          target="_blank">AudioWorklet</a> is currently available on
+          <strong>Chrome Beta</strong> behind the experimental flag or <a href=
+          "https://docs.google.com/forms/d/e/1FAIpQLSfO0_ptFl8r8G0UFhT0xhV17eabG-erUWBDiKSRDTqEZ_9ULQ/viewform">
+          Origin Trials</a>. To activate the feature locally, use the following
+          <a href=
+          "https://www.chromium.org/developers/how-tos/run-chromium-with-flags">
+          command line option</a>.
+        </p>
+        <pre><code>--enable-blink-features=Worklet,AudioWorklet</code></pre>
+        <p>
+          Alternatively, you can enable Experimental Web Platform Features in
+          Chrome's flag setting. Note that this setting enables all the
+          experimental features in browser. Copy and paste the following URL in
+          Chrome, enable the feature and relaunch the browser.
+        </p>
+        <pre>
+        <code>chrome://flags/#enable-experimental-web-platform-features</code></pre>
+        <p>
+          If the status indicator on the top-right corner of this page is not
+          green, it means either your browser does not support AudioWorklet or
+          you need to follow the instruction above to activate the feature.
+        </p>
+      </section>
+      <section class="content">
+        <h2>
+          Basic Demos
+        </h2>
+        <div class="row">
+          <div class="column">
+            <div class="demo-item">
+              <a href="basic/hello-audio-worklet.html">
+              <h4>
+                Hello AudioWorklet!
+              </h4></a>
+              <p>
+                A simple AudioWorkletNode that bypasses the incoming audio
+                stream to its output.
+              </p>
+            </div>
+          </div>
+          <div class="column">
+            <div class="demo-item">
+              <a href="basic/noise-audio-param.html">
+              <h4>
+                Noise with AudioParam Modulation
+              </h4></a>
+              <p>
+                A simple noise generator with user-defined 'gain' AudioParam
+                modulated by an OscillatorNode.
+              </p>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="column">
+            <div class="demo-item">
+              <a href="basic/bit-crusher.html">
+              <h4>
+                BitCrusher with AudioParam Automation
+              </h4></a>
+              <p>
+                A BitCrusher example from the specification, but modified to
+                demonstrate AudioParam automations
+              </p>
+            </div>
+          </div>
+          <div class="column">
+            <div class="demo-item">
+              <a href="basic/one-pole.html">
+              <h4>
+                One-Pole Filter
+              </h4></a>
+              <p>
+                A one-pole filter implementation with AudioWorkletNode.
+              </p>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="column">
+            <div class="demo-item">
+              <a href="basic/message-port.html">
+              <h4>
+                MessagePort with AudioWorklet
+              </h4></a>
+              <p>
+                Demonstrates basic bi-directional communication between
+                AudioWorkletNode and AudioWorkletProcessor.
+              </p>
+            </div>
+          </div>
+          <div class="column">
+            <div class="demo-item">
+              <a href="basic/event-processor-state.html">
+              <h4>
+                Event and AudioWorkletProcessorState
+              </h4></a>
+              <p>
+                A simple demonstration of AudioWorkletProcessorState and how to
+                catch processorstatechange event.
+              </p>
+            </div>
+          </div>
+        </div><br>
+        <br>
+        <h2>
+          Resources
+        </h2>
+        <div class="row">
+          <div class="column">
+            <div class="demo-item">
+              <a href="https://goo.gl/R2zWtR">
+              <h4>
+                Talk: AudioWorklet - What, Why and How
+              </h4></a>
+              <p>
+                An in-depth presentation about what the new AudioWorklet is,
+                why it matters for Web Audio, and how it works.
+              </p>
+            </div>
+          </div>
+          <div class="column">
+            <div class="demo-item">
+              <a href="https://goo.gl/5c5LPD">
+              <h4>
+                Slides: AudioWorklet - What, Why and How
+              </h4></a>
+              <p>
+                The slide deck for the presentation.
+              </p>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="column">
+            <div class="demo-item">
+              <a href="https://webaudio.github.io/web-audio-api/#AudioWorklet">
+              <h4>
+                Web Audio API: AudioWorklet
+              </h4></a>
+              <p>
+                AudioWorklet section in Web Audio API specification.
+              </p>
+            </div>
+          </div>
+          <div class="column">
+            <div class="demo-item">
+              <a href=
+              "https://github.com/WebAudio/web-audio-api/issues?q=is%3Aissue+audioworklet">
+              <h4>
+                Web Audio API discussions on AudioWorklet
+              </h4></a>
+              <p>
+                A set of discussions on AudioWorklet API design.
+              </p>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="column">
+            <div class="demo-item">
+              <a href="#">
+              <h4>
+                Google Developer Blog Post: AudioWorklet
+              </h4></a>
+              <p>
+                An introductory article on AudioWorklet from Google Developer
+                Portal.
+              </p>
+            </div>
+          </div>
+          <div class="column">
+            <div class="demo-item"></div>
+          </div>
+        </div>
+      </section>
+      <section class="footer">
+        <a target="_blank" href="https://goo.gl/XW3f44">Found something
+        broken?</a><br>
+        <br>
+        <p>
+          Chrome ♥ WebAudio
+        </p>
+      </section>
     </div>
-
-    <section class="nav-bar">
-      <a href="../index.html"><span>Chrome WebAudio Samples</span></a>
-      <span class="nav-divider">|</span>
-      <span>AudioWorklet</span>
-    </section>
-
-    <!-- Header and instruction -->
-    <section class="header">
-      <h1>AudioWorklet</h1>
-      <p><a href="https://webaudio.github.io/web-audio-api/#AudioWorklet" target="_blank">AudioWorklet</a> is currently available on <strong>Chrome Beta</strong> behind the experimental flag or <a href="https://docs.google.com/forms/d/e/1FAIpQLSfO0_ptFl8r8G0UFhT0xhV17eabG-erUWBDiKSRDTqEZ_9ULQ/viewform">Origin Trials</a>. To activate the feature locally, use the following <a href="https://www.chromium.org/developers/how-tos/run-chromium-with-flags">command line option</a>.</p>
-      <pre><code>--enable-blink-features=Worklet,AudioWorklet</code></pre>
-      <p>Alternatively, you can enable Experimental Web Platform Features in Chrome's flag setting. Note that this setting enables all the experimental features in browser. Copy and paste the following URL in Chrome, enable the feature and relaunch the browser.
-      </p>
-      <pre><code>chrome://flags/#enable-experimental-web-platform-features</code></pre>
-      <p>If the status indicator on the top-right corner of this page is not green, it means either your browser does not support AudioWorklet or you need to follow the instruction above to activate the feature.</p>
-    </section>
-
-    <!-- Contents -->
-    <section class="content">
-
-      <h2>Basic Demos</h2>
-      <div class="row">
-        <div class="column">
-          <div class="demo-item">
-            <a href="basic/hello-audio-worklet.html"><h4>Hello AudioWorklet!</h4></a>
-            <p>A simple AudioWorkletNode that bypasses the incoming audio stream to its output.</p>
-          </div>
-        </div>
-        <div class="column">
-          <div class="demo-item">
-            <a href="basic/noise-audio-param.html"><h4>Noise with AudioParam Modulation</h4></a>
-            <p>A simple noise generator with user-defined 'gain' AudioParam modulated by an OscillatorNode.</p>
-          </div>
-        </div>
-      </div>
-      <div class="row">
-        <div class="column">
-          <div class="demo-item">
-            <a href="basic/bit-crusher.html"><h4>BitCrusher with AudioParam Automation</h4></a>
-            <p>A BitCrusher example from the specification, but modified to demonstrate AudioParam automations</p>
-          </div>
-        </div>
-        <div class="column">
-          <div class="demo-item">
-            <a href="basic/one-pole.html"><h4>One-Pole Filter</h4></a>
-            <p>A one-pole filter implementation with AudioWorkletNode.</p>
-          </div>
-        </div>
-      </div>
-      <div class="row">
-        <div class="column">
-          <div class="demo-item">
-            <a href="basic/message-port.html"><h4>MessagePort with AudioWorklet</h4></a>
-            <p>Demonstrates basic bi-directional communication between AudioWorkletNode and AudioWorkletProcessor.</p>
-          </div>
-        </div>
-        <div class="column">
-          <div class="demo-item">
-            <a href="basic/event-processor-state.html"><h4>Event and AudioWorkletProcessorState</h4></a>
-            <p>A simple demonstration of AudioWorkletProcessorState and how to catch processorstatechange event.</p>
-          </div>
-        </div>
-      </div>
-
-      <br><br>
-
-      <h2>Resources</h2>
-      <div class="row">
-        <div class="column">
-          <div class="demo-item">
-            <a href="https://goo.gl/R2zWtR"><h4>Talk: AudioWorklet - What, Why and How</h4></a>
-            <p>An in-depth presentation about what the new AudioWorklet is, why it matters for Web Audio, and how it works.</p>
-          </div>
-        </div>
-        <div class="column">
-          <div class="demo-item">
-            <a href="https://goo.gl/5c5LPD"><h4>Slides: AudioWorklet - What, Why and How</h4></a>
-            <p>The slide deck for the presentation.</p>
-          </div>
-        </div>
-      </div>
-      <div class="row">
-        <div class="column">
-          <div class="demo-item">
-            <a href="https://webaudio.github.io/web-audio-api/#AudioWorklet"><h4>Web Audio API: AudioWorklet</h4></a>
-            <p>AudioWorklet section in Web Audio API specification.</p>
-          </div>
-        </div>
-        <div class="column">
-          <div class="demo-item">
-            <a href="https://github.com/WebAudio/web-audio-api/issues?q=is%3Aissue+audioworklet"><h4>Web Audio API discussions on AudioWorklet</h4></a>
-            <p>A set of discussions on AudioWorklet API design.</p>
-          </div>
-        </div>
-      </div>
-      <div class="row">
-        <div class="column">
-          <div class="demo-item">
-            <a href="#"><h4>Google Developer Blog Post: AudioWorklet</h4></a>
-            <p>An introductory article on AudioWorklet from Google Developer Portal.</p>
-          </div>
-        </div>
-        <div class="column">
-          <div class="demo-item">
-          </div>
-        </div>
-      </div>
-  </section>
-
-  <!-- Footer -->
-  <section class="footer">
-    <a target="_blank" href=
-        "https://bugs.chromium.org/p/chromium/issues/entry?template=Defect%20report%20from%20user&summary=[audioworklet]%20&components=Blink%3EWebAudio">Found something broken?</a>
-    <br><br>
-    <p>Chrome &#9829; WebAudio</p>
-  </section>
-
-</div>
   </body>
 </html>

--- a/audio-worklet/lib/audio-worklet-helper.js
+++ b/audio-worklet/lib/audio-worklet-helper.js
@@ -15,15 +15,10 @@ const AudioWorkletHelper = (() => {
   let eReporterDiv_;
 
   // Check if BaseAudioContext has AudioWorklet.
-  let IsAudioWorkletInBaseAudioContext_ = (() => {
-    let context = new OfflineAudioContext(1, 1, 44100);
-    return context.audioWorklet &&
-        typeof context.audioWorklet.addModule === 'function';
-  });
-
-  function isAvailable_() {
-    return IsAudioWorkletInBaseAudioContext_;
-  }
+  let context = new OfflineAudioContext(1, 1, 44100);
+  let isAudioWorkletAvailable_ = Boolean(
+      context.audioWorklet &&
+      typeof context.audioWorklet.addModule === 'function');
 
   function initializeHelper_() {
     if (reporterInitialized_) return;
@@ -78,6 +73,8 @@ const AudioWorkletHelper = (() => {
      * Check if the browser supports AudioWorklet.
      * @return {Boolean} true if the browser supports AudioWorklet.
      */
-    isAvailable: isAvailable_
+    isAvailable: () => {
+      return isAudioWorkletAvailable_;
+    }
   };
 })();

--- a/audio-worklet/lib/audio-worklet-helper.js
+++ b/audio-worklet/lib/audio-worklet-helper.js
@@ -57,7 +57,7 @@ const AudioWorkletHelper = (() => {
     addDemo: (demoFunction) => {
       window.addEventListener('load', () => {
         initializeHelper_();
-        if (isAvailable_()) {
+        if (isAudioWorkletAvailable_) {
           demoFunction_ = demoFunction;
           addButton_();
           reportMessage_('info',

--- a/resources/base-v2.css
+++ b/resources/base-v2.css
@@ -58,9 +58,7 @@ pre {
   margin: 0 6px;
 }
 
-.worklet-status {
-  background-color: #4caf50;
-  border: 0.1rem solid #4caf50;
+#worklet-indicator {
   border-radius: .4rem;
   color: #fff;
   display: inline-block;
@@ -73,4 +71,16 @@ pre {
   text-align: center;
   text-decoration: none;
   white-space: nowrap;
+}
+
+.worklet-status-pending {
+  background-color: #B0BEC5;
+}
+
+.worklet-status-found {
+  background-color: #4caf50;
+}
+
+.worklet-status-missing {
+  background-color: #DD2C00;
 }

--- a/resources/base-v2.css
+++ b/resources/base-v2.css
@@ -1,6 +1,7 @@
 /* Milligram-based Style (version 1.3.0) */
 
 body {
+  font-weight: 400;
   color: #37474F;
   letter-spacing: 0;
 }

--- a/resources/base-v2.css
+++ b/resources/base-v2.css
@@ -1,0 +1,76 @@
+/* Milligram-based Style (version 1.3.0) */
+
+body {
+  color: #37474F;
+  letter-spacing: 0;
+}
+
+section {
+  margin: 32px 0 0 0;
+}
+
+section.header {
+  
+}
+
+section.content {
+  margin: 64px 0;
+}
+
+section.footer {
+  color: #455a64;
+  font-size: 13px;
+  letter-spacing: 0.015rem;
+  text-align: center;
+  padding-bottom: 64px;
+}
+
+h1, h2, h3, h4 {
+  letter-spacing: 0.015rem;
+}
+
+a {
+  color: #03a9f4;
+}
+
+a:focus, a:hover {
+  color: #81D4FA;
+}
+
+pre {
+  border-left: 0.3rem solid #2196f3;
+  color: #455a64;
+}
+
+.demo-item > a > h4 {
+  margin-bottom: 6px;
+}
+
+.nav-bar {
+  font-size: 1.1rem;
+  font-weight: 700;
+  height: 3.8rem;
+  letter-spacing: .1rem;
+  text-transform: uppercase;
+}
+
+.nav-bar > span.nav-divider {
+  margin: 0 6px;
+}
+
+.worklet-status {
+  background-color: #4caf50;
+  border: 0.1rem solid #4caf50;
+  border-radius: .4rem;
+  color: #fff;
+  display: inline-block;
+  font-size: 1.4rem;
+  font-weight: 400;
+  height: 3.8rem;
+  letter-spacing: .05rem;
+  line-height: 3.8rem;
+  padding: 0 2.0rem;
+  text-align: center;
+  text-decoration: none;
+  white-space: nowrap;
+}


### PR DESCRIPTION
- This change is a requirement for Origin Trials process. ([link](https://www.chromium.org/blink/origin-trials/running-an-origin-trial#add-to-signup-form
))
- Currently the link to Google developer article is missing. This landing page is the prerequisite for the article to be published.
- The style change for the demo pages will be updated once this PR is merged.

[Preview](https://cdn.rawgit.com/GoogleChromeLabs/web-audio-samples/dcb3bb71f1bd8a2fbe3882f176a170c8e64d55c9/audio-worklet/index.html)