### PR TITLE
Fix stress-test bug

### DIFF
--- a/stress-test/boxes/js/lib.js
+++ b/stress-test/boxes/js/lib.js
@@ -46,8 +46,8 @@ const Lib = {
   getMousePosition: (element, clickEvent) => {
     let rect = element.getBoundingClientRect();
     return {
-      x: event.clientX - rect.left,
-      y: event.clientY - rect.top
+      x: clickEvent.clientX - rect.left,
+      y: clickEvent.clientY - rect.top
     };
   }
 };


### PR DESCRIPTION
Currently, the stress-test demo only works in Chrome, not in Firefox. Firefox throws a ```ReferenceError: event is not defined``` because the function argument is called ```clickEvent```, not ```event```. I'm not sure why the code works in Chrome, but with this change, it will work in both browsers.