### PR TITLE
Fix #157: Load fonts using https

### DIFF
--- a/samples/audio/shiny-drum-machine.html
+++ b/samples/audio/shiny-drum-machine.html
@@ -37,8 +37,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <meta name="description" content="Create custom drum beats with a few clicks.  Choose from 15 drum kits and 26 effects, and adjust the pitch of each drum.  Save and share your beats… rock on!">
 <title>WebAudio Drum Machine</title>
 
-<link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Michroma">
-<link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Droid Sans">
+<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Michroma">
+<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Droid Sans">
 <link rel="stylesheet" type="text/css" href = "style/drummachine.css" />
 
 


### PR DESCRIPTION
Gets rid of the mixed content error messages.