### PR TITLE
Substitute Atomics.notify() for Atomics.wake()

### DIFF
--- a/audio-worklet/design-pattern/shared-buffer/shared-buffer-worker.js
+++ b/audio-worklet/design-pattern/shared-buffer/shared-buffer-worker.js
@@ -29,7 +29,7 @@
 
 // Indices for the State SAB.
 const STATE = {
-  // Flag for Atomics.wait() and wake().
+  // Flag for Atomics.wait() and notify().
   'REQUEST_RENDER': 0,
 
   // Available frames in Input SAB.

--- a/audio-worklet/design-pattern/shared-buffer/shared-buffer-worklet-processor.js
+++ b/audio-worklet/design-pattern/shared-buffer/shared-buffer-worklet-processor.js
@@ -142,7 +142,7 @@ class SharedBufferWorkletProcessor extends AudioWorkletProcessor {
 
     if (this._states[STATE.IB_FRAMES_AVAILABLE] >= this._kernelLength) {
       // Now we have enough frames to process. Wake up the worker.
-      Atomics.wake(this._states, STATE.REQUEST_RENDER, 1);
+      Atomics.notify(this._states, STATE.REQUEST_RENDER, 1);
     }
 
     return true;


### PR DESCRIPTION
`wake()` is deprecated https://www.chromestatus.com/feature/6228189936353280