### PR TITLE
Improve Audio Worklet pages for browsers with no support

### DIFF
--- a/assets/Components.js
+++ b/assets/Components.js
@@ -195,6 +195,24 @@ function _getColumn(entry) {
 }
 
 
+// Check if AudioWorklet is available.
+let isAudioWorkletAvailable_ = false;
+let hasAudioWorkletDetected_ = false;
+function _detectAudioWorklet() {
+  if (hasAudioWorkletDetected_)
+    return isAudioWorkletAvailable_;
+
+  const OfflineAudioContextConstructor =
+      window.OfflineAudioContext || window.webkitOfflineAudioContext;
+  let context = new OfflineAudioContextConstructor(1, 1, 10000);
+  isAudioWorkletAvailable_ = Boolean(
+      context && context.audioWorklet &&
+      typeof context.audioWorklet.addModule === 'function');
+  hasAudioWorkletDetected_ = true;
+  return isAudioWorkletAvailable_;
+}
+
+
 /**
  * WorkletIndicator component
  */
@@ -204,14 +222,6 @@ const WorkletIndicator = () => {
       ? html`<div class="was-indicator-found">AudioWorklet Ready</div>`
       : html`<div class="was-indicator-missing">No AudioWorklet</div>`;
 };
-
-// Check if AudioWorklet is available.
-function _detectAudioWorklet() {
-  let context = new OfflineAudioContext(1, 1, 44100);
-  return Boolean(
-      context.audioWorklet &&
-      typeof context.audioWorklet.addModule === 'function');
-}
 
 
 /**
@@ -249,14 +259,17 @@ class Logger {
 const DemoRunner = (demoFunction) => {
   const sourceUrl =
       GitHubSourceUrl + window.location.pathname.slice(RepoPrefix.length);
-  const audioContext = new AudioContext();
+  const AudioContextConstructor =
+      window.AudioContext || window.webkitAudioContext;
+  const audioContext = new AudioContextConstructor();
+  const isAudioWorkletAvailable = _detectAudioWorklet();
   const logger = new Logger();
 
   // Creates a button and its logic.
   let isFirstClick = true;
   const eButton = document.createElement('button');
   eButton.textContent = 'START';
-  eButton.disabled = _detectAudioWorklet() ? false : true;
+  eButton.disabled = !isAudioWorkletAvailable;
   eButton.onclick = (event) => {
     if (eButton.textContent === 'START') {
       if (isFirstClick) {
@@ -283,6 +296,9 @@ const DemoRunner = (demoFunction) => {
           <div class="was-demo-area-source">
             <a href="${sourceUrl}">See sources on GitHub</a>
           </div>
+          ${isAudioWorkletAvailable ? '' :
+              'This browser does not support Audio Worklet yet.'
+          }
         </div>
       </div>
     </div>

--- a/audio-worklet/design-pattern/shared-buffer/index.html
+++ b/audio-worklet/design-pattern/shared-buffer/index.html
@@ -28,10 +28,12 @@
       import WorkletDemoBuilder from '../../assets/WorkletDemoBuilder.js'
       import PageData from './PageData.js';
 
-      // Import the pre-defined AudioWorkletNode subclass.
-      import SharedBufferWorkletNode from './shared-buffer-worklet-node.js';
-
       const demoCode = async (context, logger) => {
+        // Import the pre-defined AudioWorkletNode subclass dynamically. This
+        // is invoked only when Audio Worklet is detected.
+        const {default: SharedBufferWorkletNode} =
+            await import('./shared-buffer-worklet-node.js');
+
         await context.audioWorklet.addModule(
             'shared-buffer-worklet-processor.js');
         const oscillator = new OscillatorNode(context);

--- a/src/components/Components.js
+++ b/src/components/Components.js
@@ -20,7 +20,7 @@ import { html, render } from '../assets/lit-html/lib/lit-extended.js';
 
 const LogPrefix = '[Component] ';
 const GitHubSourceUrl =
-    'https://github.com/GoogleChromeLabs/web-audio-samples/tree/master/';
+    'https://github.com/GoogleChromeLabs/web-audio-samples/tree/main/';
 const RepoPrefix = '/web-audio-samples/';
 
 /**
@@ -207,12 +207,14 @@ const WorkletIndicator = () => {
 
 // Check if AudioWorklet is available.
 function _detectAudioWorklet() {
-  let context = window.OfflineAudioContext && new OfflineAudioContext(1, 1, 44100);
+  const OfflineAudioContextConstructor =
+      window.OfflineAudioContext || window.webkitOfflineAudioContext;
+  let context = new OfflineAudioContextConstructor(1, 1, 10000);
+  console.log(context);
   return Boolean(
       context && context.audioWorklet &&
       typeof context.audioWorklet.addModule === 'function');
 }
-
 
 /**
  * Logger class


### PR DESCRIPTION
Fixes #195

1. Gate duplicate creations of OfflineAudioContext in the detection code.
2. Handle browsers with old prefix.
3. Use dynamic import for the AudioWorkletNode extension for browsers with no Audio Worklet support