### PR TITLE
Persist audio recordings to IndexedDB.

### DIFF
--- a/audio-recorder/app.mjs
+++ b/audio-recorder/app.mjs
@@ -1,6 +1,6 @@
 "use strict";
 
-import {IndexedDBStorage} from './indexeddb-storage.mjs'
+import { IndexedDBStorage } from "./indexeddb-storage.mjs";
 
 const DELETE_BUTTON_SELECTOR = ".delete-button";
 
@@ -9,18 +9,18 @@ const recordOutlineEl = document.querySelector("#record-outline");
 const soundClips = document.querySelector(".sound-clips");
 const clipTemplate = document.querySelector("#clip-template");
 
-document.addEventListener('DOMContentLoaded', init);
+document.addEventListener("DOMContentLoaded", init);
 
 async function init() {
   new mdc.iconButton.MDCIconButtonToggle(recordButton);
-  recordButton.onclick = () => startRecording({storage});
+  recordButton.onclick = () => startRecording({ storage });
 
   const storage = new IndexedDBStorage();
   await storage.open();
 
   for await (const [id, blob] of storage.readAll()) {
     const clipContainer = insertClip();
-    finalizeClip({clipContainer, id, blob, storage});
+    finalizeClip({ clipContainer, id, blob, storage });
   }
 }
 
@@ -32,7 +32,7 @@ function insertClip() {
 }
 
 /** Finalizes the audio clip card by replacing the visualization with the audio element. */
-function finalizeClip({clipContainer, blob, id, storage}) {
+function finalizeClip({ clipContainer, blob, id, storage }) {
   clipContainer.querySelector(DELETE_BUTTON_SELECTOR).onclick = () => {
     clipContainer.parentNode.removeChild(clipContainer);
     storage.delete(parseInt(id));
@@ -52,25 +52,25 @@ async function getAudioStream() {
 }
 
 /** Starts recording an audio snippet in-memory and visualizes the recording waveform.  */
-async function startRecording({storage}) {
+async function startRecording({ storage }) {
   const chunks = [];
   const stream = await getAudioStream();
   if (!stream) {
     return; // Permissions have not been granted or an error occurred.
   }
-  
+
   const clipContainer = insertClip();
 
   // Start recording the microphone's audio stream in-memory.
-  const mediaRecorder = new MediaRecorder(stream );
+  const mediaRecorder = new MediaRecorder(stream);
   mediaRecorder.ondataavailable = ({ data }) => {
     chunks.push(data);
   };
   mediaRecorder.onstop = async () => {
-    recordButton.onclick = () => startRecording({storage});
+    recordButton.onclick = () => startRecording({ storage });
     const blob = new Blob(chunks, { type: mediaRecorder.mimeType });
     const id = await storage.save(blob);
-    finalizeClip({clipContainer, id, blob, storage})
+    finalizeClip({ clipContainer, id, blob, storage });
   };
   mediaRecorder.start();
 

--- a/audio-recorder/app.mjs
+++ b/audio-recorder/app.mjs
@@ -1,5 +1,7 @@
 "use strict";
 
+import {IndexedDBStorage} from './indexeddb-storage.mjs'
+
 const DELETE_BUTTON_SELECTOR = ".delete-button";
 
 const recordButton = document.querySelector("#record");
@@ -7,8 +9,37 @@ const recordOutlineEl = document.querySelector("#record-outline");
 const soundClips = document.querySelector(".sound-clips");
 const clipTemplate = document.querySelector("#clip-template");
 
-new mdc.iconButton.MDCIconButtonToggle(recordButton);
-recordButton.onclick = startRecording;
+document.addEventListener('DOMContentLoaded', init);
+
+async function init() {
+  new mdc.iconButton.MDCIconButtonToggle(recordButton);
+  recordButton.onclick = () => startRecording({storage});
+
+  const storage = new IndexedDBStorage();
+  await storage.open();
+
+  for await (const [id, blob] of storage.readAll()) {
+    const clipContainer = insertClip();
+    finalizeClip({clipContainer, id, blob, storage});
+  }
+}
+
+/** Inserts a new audio clip at the top of the list. */
+function insertClip() {
+  const clipContainer = clipTemplate.content.firstElementChild.cloneNode(true);
+  soundClips.prepend(clipContainer);
+  return clipContainer;
+}
+
+/** Finalizes the audio clip card by replacing the visualization with the audio element. */
+function finalizeClip({clipContainer, blob, id, storage}) {
+  clipContainer.querySelector(DELETE_BUTTON_SELECTOR).onclick = () => {
+    clipContainer.parentNode.removeChild(clipContainer);
+    storage.delete(parseInt(id));
+  };
+  clipContainer.querySelector("audio").src = URL.createObjectURL(blob);
+  clipContainer.classList.remove("clip-recording");
+}
 
 /** Accesses the device's microphone and returns an audio stream (or null on error). */
 async function getAudioStream() {
@@ -21,27 +52,25 @@ async function getAudioStream() {
 }
 
 /** Starts recording an audio snippet in-memory and visualizes the recording waveform.  */
-async function startRecording() {
+async function startRecording({storage}) {
   const chunks = [];
   const stream = await getAudioStream();
   if (!stream) {
     return; // Permissions have not been granted or an error occurred.
   }
-
-  // Insert a new audio clip at the top of the list.
-  const clipContainer = clipTemplate.content.firstElementChild.cloneNode(true);
-  clipContainer.querySelector(DELETE_BUTTON_SELECTOR).onclick = () => {
-    clipContainer.parentNode.removeChild(clipContainer);
-  };
-  soundClips.prepend(clipContainer);
+  
+  const clipContainer = insertClip();
 
   // Start recording the microphone's audio stream in-memory.
-  const mediaRecorder = new MediaRecorder(stream);
+  const mediaRecorder = new MediaRecorder(stream );
   mediaRecorder.ondataavailable = ({ data }) => {
     chunks.push(data);
   };
-  mediaRecorder.onstop = () => {
-    onRecordingStopped({ clipContainer, chunks });
+  mediaRecorder.onstop = async () => {
+    recordButton.onclick = () => startRecording({storage});
+    const blob = new Blob(chunks, { type: mediaRecorder.mimeType });
+    const id = await storage.save(blob);
+    finalizeClip({clipContainer, id, blob, storage})
   };
   mediaRecorder.start();
 
@@ -52,16 +81,6 @@ async function startRecording() {
     });
   };
   visualizeRecording({ stream, clipContainer });
-}
-
-/** Finalizes the audio recording.. */
-function onRecordingStopped({ clipContainer, chunks }) {
-  const blob = new Blob(chunks, { type: "audio/ogg; codecs=opus" });
-  chunks = [];
-
-  clipContainer.querySelector("audio").src = URL.createObjectURL(blob);
-  clipContainer.classList.remove("clip-recording");
-  recordButton.onclick = startRecording;
 }
 
 /** Visualizes the audio with a waveform and a loudness indicator. */

--- a/audio-recorder/index.html
+++ b/audio-recorder/index.html
@@ -80,6 +80,6 @@
       </div>
     </main>
 
-    <script src="app.js"></script>
+    <script type="module" src="app.mjs"></script>
   </body>
 </html>

--- a/audio-recorder/indexeddb-storage.mjs
+++ b/audio-recorder/indexeddb-storage.mjs
@@ -1,0 +1,97 @@
+const DB_NAME = "recordings";
+const STORE_NAME = "audio";
+
+/** Storage for audio blobs in an IndexedDB. */
+class IndexedDBStorage {
+  /** Asynchronously opens the storage. */
+  open() {
+    return new Promise((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME);
+      request.onerror = reject;
+      request.onupgradeneeded = () => {
+        // Create ObjectStore on first connection.
+        request.result.createObjectStore(STORE_NAME, { autoIncrement: true });
+      };
+      request.onsuccess = () => {
+        this.db = request.result;
+        resolve();
+      };
+    });
+  }
+
+  /** Asynchronously stores a Blob and returns the assigned ID. */
+  save(data) {
+    return new Promise((resolve, reject) => {
+      const transaction = this.db.transaction([STORE_NAME], "readwrite");
+      transaction.onerror = reject;
+      // Insert with auto-increment ID.
+      const put = transaction.objectStore(STORE_NAME).put(data);
+      put.onerror = reject;
+      put.onsuccess = (event) => {
+        resolve(event.target.result); // Return new inserted ID.
+      };
+    });
+  }
+
+  /** Asynchronously deletes a Blob by its ID. */
+  delete(id) {
+    return new Promise((resolve, reject) => {
+      const transaction = this.db.transaction([STORE_NAME], "readwrite");
+      transaction.onerror = reject;
+      transaction.onsuccess = resolve;
+      transaction.objectStore(STORE_NAME).delete(id);
+    });
+  }
+
+  /** Returns an AsyncIterable that yields Promises of [id, blob] tuples. */
+  readAll() {
+    const db = this.db; // Store db in local context - `this` is reassigned in next().
+    return {
+      [Symbol.asyncIterator]() {
+        let promise, cursor;
+
+        function next() {
+          return new Promise((resolve, reject) => {
+            // Keep resolve() and reject() in the local scope.
+            promise = { resolve, reject };
+
+            if (cursor) {
+              // cursor is undefined on the initial invocation, which triggers the
+              // data loading. Finally, cursor will be falsey when the previous next()
+              // invocation could not return any more data.
+              // Cursor being truthy indicates that the previos next() invocation
+              // returned data and there might be more. Calling continue() will invoke
+              // the onsuccess event handler with the next data entry.
+              cursor.continue();
+              return;
+            }
+
+            const transaction = db.transaction([STORE_NAME]);
+            const request = transaction.objectStore(STORE_NAME).openCursor();
+            // This event handler is defined only once, but will be called for every
+            // stored blob or until the for-await-of loop is exited. The handler needs to
+            // resolve the Promise that was returned for the latest next() invocation.
+            request.onsuccess = (event) => {
+              cursor = event.target.result;
+              if (cursor) {
+                promise.resolve({
+                  value: [cursor.key, cursor.value],
+                  done: false,
+                });
+              } else {
+                promise.resolve({ done: true });
+              }
+            };
+            request.onerror = (event) => {
+              promise.reject(event);
+            };
+          });
+        }
+
+        return { next };
+      },
+    };
+  }
+}
+
+export { IndexedDBStorage };

--- a/audio-recorder/style.css
+++ b/audio-recorder/style.css
@@ -20,6 +20,14 @@ body {
   flex-grow: 1;
 }
 
+.clip canvas {
+  display: none;
+}
+
+.clip.clip-recording canvas {
+  display: block;
+}
+
 .clip-recording .recording-invisible {
   display: none;
 }
@@ -56,4 +64,8 @@ body {
 
 .logo {
   padding: 0 5px 0 20px;
+}
+
+audio::-webkit-media-controls-enclosure {
+  background: none;
 }


### PR DESCRIPTION
See #205 

Recorder now automatically persists recorded audio clips using the browser's IndexedDB ObjectStorage. When reloading the page, recorded clips do not get lost any longer.

As a trade-off, the waveform is only shown during recording and hidden after the recording is finished. Otherwise, it would need to be persisted or recomputed when clips are being loaded from storage. Persisting the waveform would block a future implementation of a file system based storage, which could allow loading arbitrary audio files. Recomputing the waveform works very differently: AnalyserNode can not be used, because there is no audio stream. We'd need to compute it manually based on decoded audio samples, which is expensive in JavaScript and out of scope for me.

![image](https://user-images.githubusercontent.com/864168/116727595-10d60b00-a9e5-11eb-92f8-6010f748f5b8.png)
