### PR TITLE
Configure eslint.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,21 @@
+{
+    "env": {
+        "browser": true,
+        "es2021": true
+    },
+    "extends": [
+        "eslint:recommended",
+        "google"
+    ],
+    "ignorePatterns": [
+        "archive/", 
+        "audio-recorder/",
+        "audio-worklet/"
+    ],
+    "parserOptions": {
+        "ecmaVersion": 12,
+        "sourceType": "module"
+    },
+    "rules": {
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
   "name": "web-audio-samples",
   "version": "2.0.0",
-  "scripts": {},
+  "scripts": {
+    "lint": "eslint ."
+  },
   "author": "Chromium authors",
   "license": "Apache-2.0",
   "dependencies": {},
   "devDependencies": {
     "del": "^3.0.0",
+    "eslint": "^7.25.0",
+    "eslint-config-google": "^0.14.0",
     "gulp": "^3.9.1",
     "gulp-concat-css": "^3.1.0",
     "lit-html": "^0.10.2",


### PR DESCRIPTION
This PR adds eslint, configured per https://github.com/google/eslint-config-google and https://eslint.org/docs/user-guide/getting-started. You can run `npm run lint` to check the project. For now some folders like archive and audio-recorder are excluded. I'll format audio-recorder and remove it from the blocklist in a future PR.

On a side note: `package.json` is in `.gitignore` - is this intended? Typically the lockfile is checked into the source to pin versions and allow reproducible builds.

Related: #214 