### PR TITLE
Refactor Drum Machine UI and sample loading code.

### DIFF
--- a/archive/demos/shiny-drum-machine-data.js
+++ b/archive/demos/shiny-drum-machine-data.js
@@ -1,22 +1,133 @@
+/**
+ * Recursively freezes an object, prohibiting any modifications.
+ *
+ * @template T
+ * @param {T} obj object on which to lock the attributes.
+ * @return {T} frozen object
+ */
 function freeze(obj) {
-    for (const property of Object.getOwnPropertyNames(obj)) {
-        const value = obj[property];
-        if (value && typeof value === "object") {
-            freeze(value);
-        }
+  for (const property of Object.getOwnPropertyNames(obj)) {
+    const value = obj[property];
+    if (value && typeof value === 'object') {
+      freeze(value);
     }
-    return Object.freeze(obj);
+  }
+  return Object.freeze(obj);
 }
 
+/**
+ * Clones a plain object through JSON stringify and parse.
+ *
+ * @template T
+ * @param {T} obj object to clone.
+ * @return {T} cloned object
+ */
 function clone(obj) {
-    return JSON.parse(JSON.stringify(obj));
+  return JSON.parse(JSON.stringify(obj));
 }
 
 const RESET_BEAT = freeze({
-    kitIndex: 0,
-    effectIndex: 0,
+  kitIndex: 0,
+  effectIndex: 0,
+  tempo: 100,
+  swingFactor: 0,
+  effectMix: 0.25,
+  kickPitchVal: 0.5,
+  snarePitchVal: 0.5,
+  hihatPitchVal: 0.5,
+  tom1PitchVal: 0.5,
+  tom2PitchVal: 0.5,
+  tom3PitchVal: 0.5,
+  rhythm1: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  rhythm2: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  rhythm3: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  rhythm4: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  rhythm5: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  rhythm6: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+});
+
+const DEMO_BEATS = freeze([
+  {
+    kitIndex: 13,
+    effectIndex: 18,
+    tempo: 120,
+    swingFactor: 0,
+    effectMix: 0.19718309859154926,
+    kickPitchVal: 0.5,
+    snarePitchVal: 0.5,
+    hihatPitchVal: 0.5,
+    tom1PitchVal: 0.5,
+    tom2PitchVal: 0.5,
+    tom3PitchVal: 0.5,
+    rhythm1: [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    rhythm2: [0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0],
+    rhythm3: [0, 0, 0, 0, 0, 0, 2, 0, 2, 0, 0, 0, 0, 0, 0, 0],
+    rhythm4: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0],
+    rhythm5: [0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    rhythm6: [0, 0, 0, 0, 0, 0, 0, 2, 0, 2, 2, 0, 0, 0, 0, 0],
+  },
+  {
+    kitIndex: 4,
+    effectIndex: 3,
     tempo: 100,
     swingFactor: 0,
+    effectMix: 0.2,
+    kickPitchVal: 0.46478873239436624,
+    snarePitchVal: 0.45070422535211263,
+    hihatPitchVal: 0.15492957746478875,
+    tom1PitchVal: 0.7183098591549295,
+    tom2PitchVal: 0.704225352112676,
+    tom3PitchVal: 0.8028169014084507,
+    rhythm1: [2, 1, 0, 0, 0, 0, 0, 0, 2, 1, 2, 1, 0, 0, 0, 0],
+    rhythm2: [0, 0, 0, 0, 2, 0, 0, 0, 0, 1, 1, 0, 2, 0, 0, 0],
+    rhythm3: [0, 1, 2, 1, 0, 1, 2, 1, 0, 1, 2, 1, 0, 1, 2, 1],
+    rhythm4: [0, 0, 0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+    rhythm5: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0],
+    rhythm6: [0, 0, 0, 0, 0, 0, 0, 2, 1, 2, 1, 0, 0, 0, 0, 0],
+  },
+  {
+    kitIndex: 2,
+    effectIndex: 5,
+    tempo: 100,
+    swingFactor: 0,
+    effectMix: 0.25,
+    kickPitchVal: 0.5,
+    snarePitchVal: 0.5,
+    hihatPitchVal: 0.5211267605633803,
+    tom1PitchVal: 0.23943661971830987,
+    tom2PitchVal: 0.21126760563380287,
+    tom3PitchVal: 0.2535211267605634,
+    rhythm1: [2, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0],
+    rhythm2: [0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0],
+    rhythm3: [0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0],
+    rhythm4: [1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 0, 1],
+    rhythm5: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0],
+    rhythm6: [0, 0, 1, 0, 1, 0, 0, 2, 0, 2, 0, 0, 1, 0, 0, 0],
+  },
+  {
+    kitIndex: 1,
+    effectIndex: 4,
+    tempo: 120,
+    swingFactor: 0,
+    effectMix: 0.25,
+    kickPitchVal: 0.7887323943661972,
+    snarePitchVal: 0.49295774647887325,
+    hihatPitchVal: 0.5,
+    tom1PitchVal: 0.323943661971831,
+    tom2PitchVal: 0.3943661971830986,
+    tom3PitchVal: 0.323943661971831,
+    rhythm1: [2, 0, 0, 0, 0, 0, 0, 2, 2, 0, 0, 0, 0, 0, 0, 1],
+    rhythm2: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    rhythm3: [0, 0, 1, 0, 2, 0, 1, 0, 1, 0, 1, 0, 2, 0, 2, 0],
+    rhythm4: [2, 0, 2, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 0],
+    rhythm5: [0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    rhythm6: [0, 2, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0],
+  },
+  {
+    kitIndex: 0,
+    effectIndex: 1,
+    tempo: 60,
+    swingFactor: 0.5419847328244275,
     effectMix: 0.25,
     kickPitchVal: 0.5,
     snarePitchVal: 0.5,
@@ -24,305 +135,209 @@ const RESET_BEAT = freeze({
     tom1PitchVal: 0.5,
     tom2PitchVal: 0.5,
     tom3PitchVal: 0.5,
-    rhythm1: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    rhythm2: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    rhythm3: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    rhythm1: [2, 2, 0, 1, 2, 2, 0, 1, 2, 2, 0, 1, 2, 2, 0, 1],
+    rhythm2: [0, 0, 2, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0, 2, 0],
+    rhythm3: [2, 1, 1, 1, 2, 1, 1, 1, 2, 1, 1, 1, 2, 1, 1, 1],
     rhythm4: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    rhythm5: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    rhythm6: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-});
-
-const DEMO_BEATS = freeze([
-    {
-        kitIndex: 13,
-        effectIndex: 18,
-        tempo: 120,
-        swingFactor: 0,
-        effectMix: 0.19718309859154926,
-        kickPitchVal: 0.5,
-        snarePitchVal: 0.5,
-        hihatPitchVal: 0.5,
-        tom1PitchVal: 0.5,
-        tom2PitchVal: 0.5,
-        tom3PitchVal: 0.5,
-        rhythm1: [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        rhythm2: [0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0],
-        rhythm3: [0, 0, 0, 0, 0, 0, 2, 0, 2, 0, 0, 0, 0, 0, 0, 0],
-        rhythm4: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0],
-        rhythm5: [0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        rhythm6: [0, 0, 0, 0, 0, 0, 0, 2, 0, 2, 2, 0, 0, 0, 0, 0]
-    },
-    {
-        kitIndex: 4,
-        effectIndex: 3,
-        tempo: 100,
-        swingFactor: 0,
-        effectMix: 0.2,
-        kickPitchVal: 0.46478873239436624,
-        snarePitchVal: 0.45070422535211263,
-        hihatPitchVal: 0.15492957746478875,
-        tom1PitchVal: 0.7183098591549295,
-        tom2PitchVal: 0.704225352112676,
-        tom3PitchVal: 0.8028169014084507,
-        rhythm1: [2, 1, 0, 0, 0, 0, 0, 0, 2, 1, 2, 1, 0, 0, 0, 0],
-        rhythm2: [0, 0, 0, 0, 2, 0, 0, 0, 0, 1, 1, 0, 2, 0, 0, 0],
-        rhythm3: [0, 1, 2, 1, 0, 1, 2, 1, 0, 1, 2, 1, 0, 1, 2, 1],
-        rhythm4: [0, 0, 0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0],
-        rhythm5: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0],
-        rhythm6: [0, 0, 0, 0, 0, 0, 0, 2, 1, 2, 1, 0, 0, 0, 0, 0]
-    },
-    {
-        kitIndex: 2,
-        effectIndex: 5,
-        tempo: 100,
-        swingFactor: 0,
-        effectMix: 0.25,
-        kickPitchVal: 0.5,
-        snarePitchVal: 0.5,
-        hihatPitchVal: 0.5211267605633803,
-        tom1PitchVal: 0.23943661971830987,
-        tom2PitchVal: 0.21126760563380287,
-        tom3PitchVal: 0.2535211267605634,
-        rhythm1: [2, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0],
-        rhythm2: [0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0],
-        rhythm3: [0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0],
-        rhythm4: [1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 0, 1],
-        rhythm5: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0],
-        rhythm6: [0, 0, 1, 0, 1, 0, 0, 2, 0, 2, 0, 0, 1, 0, 0, 0]
-    },
-    {
-        kitIndex: 1,
-        effectIndex: 4,
-        tempo: 120,
-        swingFactor: 0,
-        effectMix: 0.25,
-        kickPitchVal: 0.7887323943661972,
-        snarePitchVal: 0.49295774647887325,
-        hihatPitchVal: 0.5,
-        tom1PitchVal: 0.323943661971831,
-        tom2PitchVal: 0.3943661971830986,
-        tom3PitchVal: 0.323943661971831,
-        rhythm1: [2, 0, 0, 0, 0, 0, 0, 2, 2, 0, 0, 0, 0, 0, 0, 1],
-        rhythm2: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        rhythm3: [0, 0, 1, 0, 2, 0, 1, 0, 1, 0, 1, 0, 2, 0, 2, 0],
-        rhythm4: [2, 0, 2, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 0],
-        rhythm5: [0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        rhythm6: [0, 2, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0]
-    },
-    {
-        kitIndex: 0,
-        effectIndex: 1,
-        tempo: 60,
-        swingFactor: 0.5419847328244275,
-        effectMix: 0.25,
-        kickPitchVal: 0.5,
-        snarePitchVal: 0.5,
-        hihatPitchVal: 0.5,
-        tom1PitchVal: 0.5,
-        tom2PitchVal: 0.5,
-        tom3PitchVal: 0.5,
-        rhythm1: [2, 2, 0, 1, 2, 2, 0, 1, 2, 2, 0, 1, 2, 2, 0, 1],
-        rhythm2: [0, 0, 2, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0, 2, 0],
-        rhythm3: [2, 1, 1, 1, 2, 1, 1, 1, 2, 1, 1, 1, 2, 1, 1, 1],
-        rhythm4: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        rhythm5: [0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0],
-        rhythm6: [1, 0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 1, 1, 1, 1, 0]
-    },
+    rhythm5: [0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0],
+    rhythm6: [1, 0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 1, 1, 1, 1, 0],
+  },
 ]);
 
 const INSTRUMENTS = freeze([
-    { name: 'Kick', pan: false, sendGain: 0.5, mainGain: 1.0 },
-    { name: 'Snare', pan: false, sendGain: 1, mainGain: 0.6 },
-    { name: 'HiHat', pan: true, sendGain: 1, mainGain: 0.7 },
-    { name: 'Tom1', pan: false, sendGain: 1, mainGain: 0.6 },
-    { name: 'Tom2', pan: false, sendGain: 1, mainGain: 0.6 },
-    { name: 'Tom3', pan: false, sendGain: 1, mainGain: 0.6 },
+  {name: 'Kick', pan: false, sendGain: 0.5, mainGain: 1.0},
+  {name: 'Snare', pan: false, sendGain: 1, mainGain: 0.6},
+  {name: 'HiHat', pan: true, sendGain: 1, mainGain: 0.7},
+  {name: 'Tom1', pan: false, sendGain: 1, mainGain: 0.6},
+  {name: 'Tom2', pan: false, sendGain: 1, mainGain: 0.6},
+  {name: 'Tom3', pan: false, sendGain: 1, mainGain: 0.6},
 ]);
 
 const KIT_DATA = freeze([
-    { id: "R8", name: "Roland R-8" },
-    { id: "CR78", name: "Roland CR-78" },
-    { id: "KPR77", name: "Korg KPR-77" },
-    { id: "LINN", name: "LinnDrum" },
-    { id: "Kit3", name: "Kit 3" },
-    { id: "Kit8", name: "Kit 8" },
-    { id: "Techno", name: "Techno" },
-    { id: "Stark", name: "Stark" },
-    { id: "breakbeat8", name: "Breakbeat 8" },
-    { id: "breakbeat9", name: "Breakbeat 9" },
-    { id: "breakbeat13", name: "Breakbeat 13" },
-    { id: "acoustic-kit", name: "Acoustic Kit" },
-    { id: "4OP-FM", name: "4OP-FM" },
-    { id: "TheCheebacabra1", name: "The Cheebacabra 1" },
-    { id: "TheCheebacabra2", name: "The Cheebacabra 2" },
+  {id: 'R8', name: 'Roland R-8'},
+  {id: 'CR78', name: 'Roland CR-78'},
+  {id: 'KPR77', name: 'Korg KPR-77'},
+  {id: 'LINN', name: 'LinnDrum'},
+  {id: 'Kit3', name: 'Kit 3'},
+  {id: 'Kit8', name: 'Kit 8'},
+  {id: 'Techno', name: 'Techno'},
+  {id: 'Stark', name: 'Stark'},
+  {id: 'breakbeat8', name: 'Breakbeat 8'},
+  {id: 'breakbeat9', name: 'Breakbeat 9'},
+  {id: 'breakbeat13', name: 'Breakbeat 13'},
+  {id: 'acoustic-kit', name: 'Acoustic Kit'},
+  {id: '4OP-FM', name: '4OP-FM'},
+  {id: 'TheCheebacabra1', name: 'The Cheebacabra 1'},
+  {id: 'TheCheebacabra2', name: 'The Cheebacabra 2'},
 ]);
 
 // Impulse responses - each one represents a unique linear effect.
 const IMPULSE_RESPONSE_DATA = freeze([
-    {
-        name: "No Effect",
-        url: "",
-        dryMix: 1,
-        wetMix: 0
-    },
-    {
-        name: "Spreader 1",
-        url: "impulse-responses/spreader50-65ms.wav",
-        dryMix: 0.8,
-        wetMix: 1.4
-    },
-    {
-        name: "Spreader 2",
-        url: "impulse-responses/noise-spreader1.wav",
-        dryMix: 1,
-        wetMix: 1
-    },
-    {
-        name: "Spring Reverb",
-        url: "impulse-responses/feedback-spring.wav",
-        dryMix: 1,
-        wetMix: 1
-    },
-    {
-        name: "Space Oddity",
-        url: "impulse-responses/filter-rhythm3.wav",
-        dryMix: 1,
-        wetMix: 0.7
-    },
-    {
-        name: "Reverse",
-        url: "impulse-responses/spatialized5.wav",
-        dryMix: 1,
-        wetMix: 1
-    },
-    {
-        name: "Huge Reverse",
-        url: "impulse-responses/matrix6-backwards.wav",
-        dryMix: 0,
-        wetMix: 0.7
-    },
-    {
-        name: "Telephone Filter",
-        url: "impulse-responses/filter-telephone.wav",
-        dryMix: 0,
-        wetMix: 1.2
-    },
-    {
-        name: "Lopass Filter",
-        url: "impulse-responses/filter-lopass160.wav",
-        dryMix: 0,
-        wetMix: 0.5
-    },
-    {
-        name: "Hipass Filter",
-        url: "impulse-responses/filter-hipass5000.wav",
-        dryMix: 0,
-        wetMix: 4.0
-    },
-    {
-        name: "Comb 1",
-        url: "impulse-responses/comb-saw1.wav",
-        dryMix: 0,
-        wetMix: 0.7
-    },
-    {
-        name: "Comb 2",
-        url: "impulse-responses/comb-saw2.wav",
-        dryMix: 0,
-        wetMix: 1.0
-    },
-    {
-        name: "Cosmic Ping",
-        url: "impulse-responses/cosmic-ping-long.wav",
-        dryMix: 0,
-        wetMix: 0.9
-    },
-    {
-        name: "Kitchen",
-        url: "impulse-responses/house-impulses/kitchen-true-stereo.wav",
-        dryMix: 1,
-        wetMix: 1
-    },
-    {
-        name: "Living Room",
-        url: "impulse-responses/house-impulses/dining-living-true-stereo.wav",
-        dryMix: 1,
-        wetMix: 1
-    },
-    {
-        name: "Living-Bedroom",
-        url: "impulse-responses/house-impulses/living-bedroom-leveled.wav",
-        dryMix: 1,
-        wetMix: 1
-    },
-    {
-        name: "Dining-Far-Kitchen",
-        url: "impulse-responses/house-impulses/dining-far-kitchen.wav",
-        dryMix: 1,
-        wetMix: 1
-    },
-    {
-        name: "Medium Hall 1",
-        url: "impulse-responses/matrix-reverb2.wav",
-        dryMix: 1,
-        wetMix: 1
-    },
-    {
-        name: "Medium Hall 2",
-        url: "impulse-responses/matrix-reverb3.wav",
-        dryMix: 1,
-        wetMix: 1
-    },
-    {
-        name: "Large Hall",
-        url: "impulse-responses/spatialized4.wav",
-        dryMix: 1,
-        wetMix: 0.5
-    },
-    {
-        name: "Peculiar",
-        url: "impulse-responses/peculiar-backwards.wav",
-        dryMix: 1,
-        wetMix: 1
-    },
-    {
-        name: "Backslap",
-        url: "impulse-responses/backslap1.wav",
-        dryMix: 1,
-        wetMix: 1
-    },
-    {
-        name: "Warehouse",
-        url: "impulse-responses/tim-warehouse/cardiod-rear-35-10/cardiod-rear-levelled.wav",
-        dryMix: 1,
-        wetMix: 1
-    },
-    {
-        name: "Diffusor",
-        url: "impulse-responses/diffusor3.wav",
-        dryMix: 1,
-        wetMix: 1
-    },
-    {
-        name: "Binaural Hall",
-        url: "impulse-responses/bin_dfeq/s2_r4_bd.wav",
-        dryMix: 1,
-        wetMix: 0.5
-    },
-    {
-        name: "Huge",
-        url: "impulse-responses/matrix-reverb6.wav",
-        dryMix: 1,
-        wetMix: 0.7
-    },
+  {
+    name: 'No Effect',
+    url: '',
+    dryMix: 1,
+    wetMix: 0,
+  },
+  {
+    name: 'Spreader 1',
+    url: 'impulse-responses/spreader50-65ms.wav',
+    dryMix: 0.8,
+    wetMix: 1.4,
+  },
+  {
+    name: 'Spreader 2',
+    url: 'impulse-responses/noise-spreader1.wav',
+    dryMix: 1,
+    wetMix: 1,
+  },
+  {
+    name: 'Spring Reverb',
+    url: 'impulse-responses/feedback-spring.wav',
+    dryMix: 1,
+    wetMix: 1,
+  },
+  {
+    name: 'Space Oddity',
+    url: 'impulse-responses/filter-rhythm3.wav',
+    dryMix: 1,
+    wetMix: 0.7,
+  },
+  {
+    name: 'Reverse',
+    url: 'impulse-responses/spatialized5.wav',
+    dryMix: 1,
+    wetMix: 1,
+  },
+  {
+    name: 'Huge Reverse',
+    url: 'impulse-responses/matrix6-backwards.wav',
+    dryMix: 0,
+    wetMix: 0.7,
+  },
+  {
+    name: 'Telephone Filter',
+    url: 'impulse-responses/filter-telephone.wav',
+    dryMix: 0,
+    wetMix: 1.2,
+  },
+  {
+    name: 'Lopass Filter',
+    url: 'impulse-responses/filter-lopass160.wav',
+    dryMix: 0,
+    wetMix: 0.5,
+  },
+  {
+    name: 'Hipass Filter',
+    url: 'impulse-responses/filter-hipass5000.wav',
+    dryMix: 0,
+    wetMix: 4.0,
+  },
+  {
+    name: 'Comb 1',
+    url: 'impulse-responses/comb-saw1.wav',
+    dryMix: 0,
+    wetMix: 0.7,
+  },
+  {
+    name: 'Comb 2',
+    url: 'impulse-responses/comb-saw2.wav',
+    dryMix: 0,
+    wetMix: 1.0,
+  },
+  {
+    name: 'Cosmic Ping',
+    url: 'impulse-responses/cosmic-ping-long.wav',
+    dryMix: 0,
+    wetMix: 0.9,
+  },
+  {
+    name: 'Kitchen',
+    url: 'impulse-responses/house-impulses/kitchen-true-stereo.wav',
+    dryMix: 1,
+    wetMix: 1,
+  },
+  {
+    name: 'Living Room',
+    url: 'impulse-responses/house-impulses/dining-living-true-stereo.wav',
+    dryMix: 1,
+    wetMix: 1,
+  },
+  {
+    name: 'Living-Bedroom',
+    url: 'impulse-responses/house-impulses/living-bedroom-leveled.wav',
+    dryMix: 1,
+    wetMix: 1,
+  },
+  {
+    name: 'Dining-Far-Kitchen',
+    url: 'impulse-responses/house-impulses/dining-far-kitchen.wav',
+    dryMix: 1,
+    wetMix: 1,
+  },
+  {
+    name: 'Medium Hall 1',
+    url: 'impulse-responses/matrix-reverb2.wav',
+    dryMix: 1,
+    wetMix: 1,
+  },
+  {
+    name: 'Medium Hall 2',
+    url: 'impulse-responses/matrix-reverb3.wav',
+    dryMix: 1,
+    wetMix: 1,
+  },
+  {
+    name: 'Large Hall',
+    url: 'impulse-responses/spatialized4.wav',
+    dryMix: 1,
+    wetMix: 0.5,
+  },
+  {
+    name: 'Peculiar',
+    url: 'impulse-responses/peculiar-backwards.wav',
+    dryMix: 1,
+    wetMix: 1,
+  },
+  {
+    name: 'Backslap',
+    url: 'impulse-responses/backslap1.wav',
+    dryMix: 1,
+    wetMix: 1,
+  },
+  {
+    name: 'Warehouse',
+    url: 'impulse-responses/tim-warehouse/cardiod-rear-35-10/' +
+          'cardiod-rear-levelled.wav',
+    dryMix: 1,
+    wetMix: 1,
+  },
+  {
+    name: 'Diffusor',
+    url: 'impulse-responses/diffusor3.wav',
+    dryMix: 1,
+    wetMix: 1,
+  },
+  {
+    name: 'Binaural Hall',
+    url: 'impulse-responses/bin_dfeq/s2_r4_bd.wav',
+    dryMix: 1,
+    wetMix: 0.5,
+  },
+  {
+    name: 'Huge',
+    url: 'impulse-responses/matrix-reverb6.wav',
+    dryMix: 1,
+    wetMix: 0.7,
+  },
 ]);
 
 export {
-    RESET_BEAT,
-    DEMO_BEATS,
-    INSTRUMENTS,
-    KIT_DATA,
-    IMPULSE_RESPONSE_DATA,
-    freeze,
-    clone,
+  RESET_BEAT,
+  DEMO_BEATS,
+  INSTRUMENTS,
+  KIT_DATA,
+  IMPULSE_RESPONSE_DATA,
+  freeze,
+  clone,
 };

--- a/archive/demos/shiny-drum-machine-data.js
+++ b/archive/demos/shiny-drum-machine-data.js
@@ -1,0 +1,321 @@
+function freeze(obj) {
+    for(const property of Object.getOwnPropertyNames(obj)) {
+        const value = obj[property];
+        if (value && typeof value === "object") {
+            freeze(value);
+          }
+    }
+    return Object.freeze(obj);
+}
+
+function clone(obj) {
+    return JSON.parse(JSON.stringify(obj));
+}
+
+const RESET_BEAT = freeze({
+    kitIndex: 0,
+    effectIndex: 0,
+    tempo: 100,
+    swingFactor: 0,
+    effectMix: 0.25,
+    kickPitchVal: 0.5,
+    snarePitchVal: 0.5,
+    hihatPitchVal: 0.5,
+    tom1PitchVal: 0.5,
+    tom2PitchVal: 0.5,
+    tom3PitchVal: 0.5,
+    rhythm1: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    rhythm2: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    rhythm3: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    rhythm4: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    rhythm5: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    rhythm6: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+});
+
+const DEMO_BEATS = freeze([
+    {
+        kitIndex: 13,
+        effectIndex: 18,
+        tempo: 120,
+        swingFactor: 0,
+        effectMix: 0.19718309859154926,
+        kickPitchVal: 0.5,
+        snarePitchVal: 0.5,
+        hihatPitchVal: 0.5,
+        tom1PitchVal: 0.5,
+        tom2PitchVal: 0.5,
+        tom3PitchVal: 0.5,
+        rhythm1: [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        rhythm2: [0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0],
+        rhythm3: [0, 0, 0, 0, 0, 0, 2, 0, 2, 0, 0, 0, 0, 0, 0, 0],
+        rhythm4: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0],
+        rhythm5: [0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        rhythm6: [0, 0, 0, 0, 0, 0, 0, 2, 0, 2, 2, 0, 0, 0, 0, 0]
+    },
+    {
+        kitIndex: 4,
+        effectIndex: 3,
+        tempo: 100,
+        swingFactor: 0,
+        effectMix: 0.2,
+        kickPitchVal: 0.46478873239436624,
+        snarePitchVal: 0.45070422535211263,
+        hihatPitchVal: 0.15492957746478875,
+        tom1PitchVal: 0.7183098591549295,
+        tom2PitchVal: 0.704225352112676,
+        tom3PitchVal: 0.8028169014084507,
+        rhythm1: [2, 1, 0, 0, 0, 0, 0, 0, 2, 1, 2, 1, 0, 0, 0, 0],
+        rhythm2: [0, 0, 0, 0, 2, 0, 0, 0, 0, 1, 1, 0, 2, 0, 0, 0],
+        rhythm3: [0, 1, 2, 1, 0, 1, 2, 1, 0, 1, 2, 1, 0, 1, 2, 1],
+        rhythm4: [0, 0, 0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+        rhythm5: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0],
+        rhythm6: [0, 0, 0, 0, 0, 0, 0, 2, 1, 2, 1, 0, 0, 0, 0, 0]
+    },
+    {
+        kitIndex: 2,
+        effectIndex: 5,
+        tempo: 100,
+        swingFactor: 0,
+        effectMix: 0.25,
+        kickPitchVal: 0.5,
+        snarePitchVal: 0.5,
+        hihatPitchVal: 0.5211267605633803,
+        tom1PitchVal: 0.23943661971830987,
+        tom2PitchVal: 0.21126760563380287,
+        tom3PitchVal: 0.2535211267605634,
+        rhythm1: [2, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0],
+        rhythm2: [0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0],
+        rhythm3: [0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0],
+        rhythm4: [1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 0, 1],
+        rhythm5: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0],
+        rhythm6: [0, 0, 1, 0, 1, 0, 0, 2, 0, 2, 0, 0, 1, 0, 0, 0]
+    },
+    {
+        kitIndex: 1,
+        effectIndex: 4,
+        tempo: 120,
+        swingFactor: 0,
+        effectMix: 0.25,
+        kickPitchVal: 0.7887323943661972,
+        snarePitchVal: 0.49295774647887325,
+        hihatPitchVal: 0.5,
+        tom1PitchVal: 0.323943661971831,
+        tom2PitchVal: 0.3943661971830986,
+        tom3PitchVal: 0.323943661971831,
+        rhythm1: [2, 0, 0, 0, 0, 0, 0, 2, 2, 0, 0, 0, 0, 0, 0, 1],
+        rhythm2: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        rhythm3: [0, 0, 1, 0, 2, 0, 1, 0, 1, 0, 1, 0, 2, 0, 2, 0],
+        rhythm4: [2, 0, 2, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 0],
+        rhythm5: [0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        rhythm6: [0, 2, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0]
+    },
+    {
+        kitIndex: 0,
+        effectIndex: 1,
+        tempo: 60,
+        swingFactor: 0.5419847328244275,
+        effectMix: 0.25,
+        kickPitchVal: 0.5,
+        snarePitchVal: 0.5,
+        hihatPitchVal: 0.5,
+        tom1PitchVal: 0.5,
+        tom2PitchVal: 0.5,
+        tom3PitchVal: 0.5,
+        rhythm1: [2, 2, 0, 1, 2, 2, 0, 1, 2, 2, 0, 1, 2, 2, 0, 1],
+        rhythm2: [0, 0, 2, 0, 0, 0, 2, 0, 0, 0, 2, 0, 0, 0, 2, 0],
+        rhythm3: [2, 1, 1, 1, 2, 1, 1, 1, 2, 1, 1, 1, 2, 1, 1, 1],
+        rhythm4: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        rhythm5: [0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0],
+        rhythm6: [1, 0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 1, 1, 1, 1, 0]
+    },
+]);
+
+const INSTRUMENTS = freeze(['Kick', 'Snare', 'HiHat', 'Tom1', 'Tom2', 'Tom3']);
+
+const KIT_DATA = freeze([
+    { id: "R8", name: "Roland R-8" },
+    { id: "CR78", name: "Roland CR-78" },
+    { id: "KPR77", name: "Korg KPR-77" },
+    { id: "LINN", name: "LinnDrum" },
+    { id: "Kit3", name: "Kit 3" },
+    { id: "Kit8", name: "Kit 8" },
+    { id: "Techno", name: "Techno" },
+    { id: "Stark", name: "Stark" },
+    { id: "breakbeat8", name: "Breakbeat 8" },
+    { id: "breakbeat9", name: "Breakbeat 9" },
+    { id: "breakbeat13", name: "Breakbeat 13" },
+    { id: "acoustic-kit", name: "Acoustic Kit" },
+    { id: "4OP-FM", name: "4OP-FM" },
+    { id: "TheCheebacabra1", name: "The Cheebacabra 1" },
+    { id: "TheCheebacabra2", name: "The Cheebacabra 2" },
+]);
+
+// Impulse responses - each one represents a unique linear effect.
+const IMPULSE_RESPONSE_DATA = freeze([
+    {
+        name: "No Effect",
+        url: "",
+        dryMix: 1,
+        wetMix: 0
+    },
+    {
+        name: "Spreader 1",
+        url: "impulse-responses/spreader50-65ms.wav",
+        dryMix: 0.8,
+        wetMix: 1.4
+    },
+    {
+        name: "Spreader 2",
+        url: "impulse-responses/noise-spreader1.wav",
+        dryMix: 1,
+        wetMix: 1
+    },
+    {
+        name: "Spring Reverb",
+        url: "impulse-responses/feedback-spring.wav",
+        dryMix: 1,
+        wetMix: 1
+    },
+    {
+        name: "Space Oddity",
+        url: "impulse-responses/filter-rhythm3.wav",
+        dryMix: 1,
+        wetMix: 0.7
+    },
+    {
+        name: "Reverse",
+        url: "impulse-responses/spatialized5.wav",
+        dryMix: 1,
+        wetMix: 1
+    },
+    {
+        name: "Huge Reverse",
+        url: "impulse-responses/matrix6-backwards.wav",
+        dryMix: 0,
+        wetMix: 0.7
+    },
+    {
+        name: "Telephone Filter",
+        url: "impulse-responses/filter-telephone.wav",
+        dryMix: 0,
+        wetMix: 1.2
+    },
+    {
+        name: "Lopass Filter",
+        url: "impulse-responses/filter-lopass160.wav",
+        dryMix: 0,
+        wetMix: 0.5
+    },
+    {
+        name: "Hipass Filter",
+        url: "impulse-responses/filter-hipass5000.wav",
+        dryMix: 0,
+        wetMix: 4.0
+    },
+    {
+        name: "Comb 1",
+        url: "impulse-responses/comb-saw1.wav",
+        dryMix: 0,
+        wetMix: 0.7
+    },
+    {
+        name: "Comb 2",
+        url: "impulse-responses/comb-saw2.wav",
+        dryMix: 0,
+        wetMix: 1.0
+    },
+    {
+        name: "Cosmic Ping",
+        url: "impulse-responses/cosmic-ping-long.wav",
+        dryMix: 0,
+        wetMix: 0.9
+    },
+    {
+        name: "Kitchen",
+        url: "impulse-responses/house-impulses/kitchen-true-stereo.wav",
+        dryMix: 1,
+        wetMix: 1
+    },
+    {
+        name: "Living Room",
+        url: "impulse-responses/house-impulses/dining-living-true-stereo.wav",
+        dryMix: 1,
+        wetMix: 1
+    },
+    {
+        name: "Living-Bedroom",
+        url: "impulse-responses/house-impulses/living-bedroom-leveled.wav",
+        dryMix: 1,
+        wetMix: 1
+    },
+    {
+        name: "Dining-Far-Kitchen",
+        url: "impulse-responses/house-impulses/dining-far-kitchen.wav",
+        dryMix: 1,
+        wetMix: 1
+    },
+    {
+        name: "Medium Hall 1",
+        url: "impulse-responses/matrix-reverb2.wav",
+        dryMix: 1,
+        wetMix: 1
+    },
+    {
+        name: "Medium Hall 2",
+        url: "impulse-responses/matrix-reverb3.wav",
+        dryMix: 1,
+        wetMix: 1
+    },
+    {
+        name: "Large Hall",
+        url: "impulse-responses/spatialized4.wav",
+        dryMix: 1,
+        wetMix: 0.5
+    },
+    {
+        name: "Peculiar",
+        url: "impulse-responses/peculiar-backwards.wav",
+        dryMix: 1,
+        wetMix: 1
+    },
+    {
+        name: "Backslap",
+        url: "impulse-responses/backslap1.wav",
+        dryMix: 1,
+        wetMix: 1
+    },
+    {
+        name: "Warehouse",
+        url: "impulse-responses/tim-warehouse/cardiod-rear-35-10/cardiod-rear-levelled.wav",
+        dryMix: 1,
+        wetMix: 1
+    },
+    {
+        name: "Diffusor",
+        url: "impulse-responses/diffusor3.wav",
+        dryMix: 1,
+        wetMix: 1
+    },
+    {
+        name: "Binaural Hall",
+        url: "impulse-responses/bin_dfeq/s2_r4_bd.wav",
+        dryMix: 1,
+        wetMix: 0.5
+    },
+    {
+        name: "Huge",
+        url: "impulse-responses/matrix-reverb6.wav",
+        dryMix: 1,
+        wetMix: 0.7
+    },
+]);
+
+export {
+    RESET_BEAT,
+    DEMO_BEATS,
+    INSTRUMENTS,
+    KIT_DATA,
+    IMPULSE_RESPONSE_DATA,
+    freeze,
+    clone,
+};

--- a/archive/demos/shiny-drum-machine-data.js
+++ b/archive/demos/shiny-drum-machine-data.js
@@ -1,9 +1,9 @@
 function freeze(obj) {
-    for(const property of Object.getOwnPropertyNames(obj)) {
+    for (const property of Object.getOwnPropertyNames(obj)) {
         const value = obj[property];
         if (value && typeof value === "object") {
             freeze(value);
-          }
+        }
     }
     return Object.freeze(obj);
 }
@@ -130,7 +130,14 @@ const DEMO_BEATS = freeze([
     },
 ]);
 
-const INSTRUMENTS = freeze(['Kick', 'Snare', 'HiHat', 'Tom1', 'Tom2', 'Tom3']);
+const INSTRUMENTS = freeze([
+    { name: 'Kick', pan: false, sendGain: 0.5, mainGain: 1.0 },
+    { name: 'Snare', pan: false, sendGain: 1, mainGain: 0.6 },
+    { name: 'HiHat', pan: true, sendGain: 1, mainGain: 0.7 },
+    { name: 'Tom1', pan: false, sendGain: 1, mainGain: 0.6 },
+    { name: 'Tom2', pan: false, sendGain: 1, mainGain: 0.6 },
+    { name: 'Tom3', pan: false, sendGain: 1, mainGain: 0.6 },
+]);
 
 const KIT_DATA = freeze([
     { id: "R8", name: "Roland R-8" },

--- a/archive/demos/shiny-drum-machine-ui.js
+++ b/archive/demos/shiny-drum-machine-ui.js
@@ -1,272 +1,279 @@
 class Slider {
-    constructor(element, opts = {}) {
-        this.element = element;
-        this.onchange = () => {};
+  constructor(element, opts = {}) {
+    this.element = element;
+    this.onchange = () => {};
 
-        element.addEventListener('input', () => {
-            this.onchange(this.value);
-        });
+    element.addEventListener('input', () => {
+      this.onchange(this.value);
+    });
 
-        if(opts && opts.doubleClickValue) {
-            element.addEventListener('dblclick', () => {
-                this.value = opts.doubleClickValue;
-                this.onchange(this.value);
-            });
-        }
+    if (opts && opts.doubleClickValue) {
+      element.addEventListener('dblclick', () => {
+        this.value = opts.doubleClickValue;
+        this.onchange(this.value);
+      });
     }
+  }
 
-    get value() {
-        return new Number(this.element.value) / 100;
-    }
+  get value() {
+    return new Number(this.element.value) / 100;
+  }
 
-    set value(value) {
-        this.element.value = value * 100;
-    }
+  set value(value) {
+    this.element.value = value * 100;
+  }
 }
 
 class EffectSlider extends Slider {
-    constructor(container=document) {
-        super(container.getElementById('effect_thumb'));
-    }
+  constructor(container=document) {
+    super(container.getElementById('effect_thumb'));
+  }
 }
 
 class SwingSlider extends Slider {
-    constructor(container=document) {
-        super(container.getElementById('swing_thumb'));
-    }
+  constructor(container=document) {
+    super(container.getElementById('swing_thumb'));
+  }
 }
 
 class PitchSliders {
-    constructor(container=document) {
-        this.sliders = {};
-        this.onPitchChange = (instrument, pitch) => {};
-        for(const el of container.querySelectorAll('[data-instrument][data-pitch]')) {
-            this.sliders[el.dataset.instrument] = new Slider(el, {doubleClickValue: 0.5});
-            this.sliders[el.dataset.instrument].onchange = (value) => {
-                this.onPitchChange(el.dataset.instrument, value);
-            };
-        }
+  constructor(container=document) {
+    this.sliders = {};
+    this.onPitchChange = (instrument, pitch) => {};
+    for (const el of container.querySelectorAll('[data-instrument][data-pitch]')) {
+      this.sliders[el.dataset.instrument] = new Slider(el, {doubleClickValue: 0.5});
+      this.sliders[el.dataset.instrument].onchange = (value) => {
+        this.onPitchChange(el.dataset.instrument, value);
+      };
     }
+  }
 
-    setPitch(instrument, pitch) {
-        this.sliders[instrument].value = pitch;
-    }
+  setPitch(instrument, pitch) {
+    this.sliders[instrument].value = pitch;
+  }
 }
 
 class Button {
-    constructor(element, onclick = () => {}) {
-        this.element = element;
-        this.onclick = onclick;
-        element.addEventListener('click', (event) => this.onclick(event));
-    }
+  constructor(element, onclick = () => {}) {
+    this.element = element;
+    this.onclick = onclick;
+    element.addEventListener('click', (event) => this.onclick(event));
+  }
 
-    get state() {
-        return this.element.dataset.state;
-    }
+  get state() {
+    return this.element.dataset.state;
+  }
 
-    set state(value) {
-        this.element.dataset.state = value;
-    }
+  set state(value) {
+    this.element.dataset.state = value;
+  }
 }
 
 class PlayButton extends Button {
-    constructor() {
-        super(document.getElementById('play'));
-    }
+  constructor() {
+    super(document.getElementById('play'));
+  }
 }
 
 class ResetButton extends Button {
-    constructor() {
-        super(document.getElementById('reset'));
-    }
+  constructor() {
+    super(document.getElementById('reset'));
+  }
 }
 
 class Playheads {
-    constructor() {
-        this.current = 0;
-    }
+  constructor() {
+    this.current = 0;
+  }
 
-    drawPlayhead(index) {
-        // TODO: Refactor, replace with data attributes.
-        this.current = index;
-        const lastIndex = (index + 15) % 16;
+  drawPlayhead(index) {
+    // TODO: Refactor, replace with data attributes.
+    this.current = index;
+    const lastIndex = (index + 15) % 16;
 
-        const elNew = document.getElementById('LED_' + index);
-        const elOld = document.getElementById('LED_' + lastIndex);
-        
-        elNew.src = 'images/LED_on.png';
-        elOld.src = 'images/LED_off.png';
-    }
+    const elNew = document.getElementById('LED_' + index);
+    const elOld = document.getElementById('LED_' + lastIndex);
 
-    off() {
-        const el = document.getElementById(`LED_${this.current}`);
-        el.src = 'images/LED_off.png';
-    }
+    elNew.src = 'images/LED_on.png';
+    elOld.src = 'images/LED_off.png';
+  }
+
+  off() {
+    const el = document.getElementById(`LED_${this.current}`);
+    el.src = 'images/LED_off.png';
+  }
 }
 
 class DemoButtons {
-    constructor(container = document, onDemoClick = () => {}) {
-        this.buttons = {};
-        this.onDemoClick = onDemoClick;
+  constructor(container = document, onDemoClick = () => {}) {
+    this.buttons = {};
+    this.onDemoClick = onDemoClick;
 
-        const onButtonClick = (event) => {
-            this.onDemoClick(new Number(event.target.dataset.demo));
-        };
+    const onButtonClick = (event) => {
+      this.onDemoClick(new Number(event.target.dataset.demo));
+    };
 
-        for(const element of container.querySelectorAll(`[data-demo]`)) {
-            const demoIndex = new Number(element.dataset.demo);
-            this.buttons[demoIndex] = new Button(element, onButtonClick);
-        }
+    for (const element of container.querySelectorAll(`[data-demo]`)) {
+      const demoIndex = new Number(element.dataset.demo);
+      this.buttons[demoIndex] = new Button(element, onButtonClick);
     }
+  }
 
-    markDemoAvailable(demoIndex) {
-        this.buttons[demoIndex].state = "loaded";
-    }
+  markDemoAvailable(demoIndex) {
+    this.buttons[demoIndex].state = 'loaded';
+  }
 }
 
 class Picker {
-    constructor(element) {
-        this.onSelect = (index) => {};
-        this.element = element;
-        this.element.addEventListener('change', () => this.onSelect(this.element.selectedIndex));
-    }
+  constructor(element) {
+    this.onSelect = (index) => {};
+    this.element = element;
+    this.element.addEventListener('change', () => this.onSelect(this.element.selectedIndex));
+  }
 
-    addOptions(names) {
-        for(const name of names) {
-            this.element.add(new Option(name));
-        }
+  addOptions(names) {
+    for (const name of names) {
+      this.element.add(new Option(name));
     }
+  }
 
-    select(index) {
-        this.element.selectedIndex = index;
-    }
+  select(index) {
+    this.element.selectedIndex = index;
+  }
 }
 
 class EffectPicker extends Picker {
-    constructor(container=document) {
-        super(container.getElementById('effectlist'));
-    }
+  constructor(container=document) {
+    super(container.getElementById('effectlist'));
+  }
 }
 
 class KitPicker extends Picker {
-    constructor(container=document) {
-        super(container.getElementById('kitlist'));
-    }
+  constructor(container=document) {
+    super(container.getElementById('kitlist'));
+  }
 }
 
 class TempoInput {
-    constructor({min, max, step}) {
-        this.labelElement = document.getElementById('tempo');
-        this.onTempoChange = (tempo) => {};
+  constructor({min, max, step}) {
+    this.labelElement = document.getElementById('tempo');
+    this.onTempoChange = (tempo) => {};
 
-        document.getElementById('tempoinc').addEventListener('click', () => {
-            this.value += this.step;
-            this.onTempoChange(this.value);
-        });
+    document.getElementById('tempoinc').addEventListener('click', () => {
+      this.value += this.step;
+      this.onTempoChange(this.value);
+    });
 
-        document.getElementById('tempodec').addEventListener('click', () => {
-            this.value -= this.step;
-            this.onTempoChange(this.value);
-        });
+    document.getElementById('tempodec').addEventListener('click', () => {
+      this.value -= this.step;
+      this.onTempoChange(this.value);
+    });
 
-        this.min = min;
-        this.max = max;
-        this.step = step;
-    }
+    this.min = min;
+    this.max = max;
+    this.step = step;
+  }
 
-    set value(value) {
-        this.labelElement.innerText = Math.min(this.max, Math.max(this.min, value));
-    }
+  set value(value) {
+    this.labelElement.innerText = Math.min(this.max, Math.max(this.min, value));
+  }
 
-    get value() {
-        return new Number(this.labelElement.innerText);
-    }
+  get value() {
+    return new Number(this.labelElement.innerText);
+  }
 }
 
 class Notes {
-    constructor() {
-        this.onClick = (instrument, rhythm) => {};
+  constructor() {
+    this.onClick = (instrument, rhythm) => {};
 
-        this.buttons = {};
-        for (const el of document.querySelectorAll(`[data-instrument][data-rhythm]`)) {
-            const instrument = el.dataset.instrument;
-            const rhythm = new Number(el.dataset.rhythm);
+    this.buttons = {};
+    for (const el of document.querySelectorAll(`[data-instrument][data-rhythm]`)) {
+      const instrument = el.dataset.instrument;
+      const rhythm = new Number(el.dataset.rhythm);
 
-            if(!this.buttons[instrument]) {
-                this.buttons[instrument] = {};
-            }
+      if (!this.buttons[instrument]) {
+        this.buttons[instrument] = {};
+      }
 
-            this.buttons[instrument][rhythm] = new Button(el);
-            this.buttons[instrument][rhythm].onclick = () => this.onClick(instrument, rhythm);
-        }
+      this.buttons[instrument][rhythm] = new Button(el);
+      this.buttons[instrument][rhythm].onclick = () => this.onClick(instrument, rhythm);
     }
+  }
 
-    setNote(instrument, rhythmIndex, note) {
-        this.buttons[instrument][rhythmIndex].state = note;
-    }
+  setNote(instrument, rhythmIndex, note) {
+    this.buttons[instrument][rhythmIndex].state = note;
+  }
 }
 
 class Modal {
-    constructor(element) {
-        this.element = element;
-    }
+  constructor(element) {
+    this.element = element;
+  }
 
-    toggleVisibility() {
-        document.getElementById('pad').classList.toggle('active');
-        document.getElementById('params').classList.toggle('active');
-        document.getElementById('tools').classList.toggle('active');
-        this.element.classList.toggle('active');
-    }
+  toggleVisibility() {
+    document.getElementById('pad').classList.toggle('active');
+    document.getElementById('params').classList.toggle('active');
+    document.getElementById('tools').classList.toggle('active');
+    this.element.classList.toggle('active');
+  }
 }
 
 class SaveModal extends Modal {
-    constructor(getDataCallback) {
-        super(document.getElementById('save_container'));
-        this.textarea = document.getElementById('save_textarea');
-        document.getElementById('save_ok').addEventListener('click', () => {
-            this.toggleVisibility();
-        });
-        document.getElementById('save').addEventListener('click', () => {
-            this.textarea.value = getDataCallback();
-            this.toggleVisibility();
-        });
-    }
+  constructor(getDataCallback) {
+    super(document.getElementById('save_container'));
+    this.textarea = document.getElementById('save_textarea');
+    document.getElementById('save_ok').addEventListener('click', () => {
+      this.toggleVisibility();
+    });
+    document.getElementById('save').addEventListener('click', () => {
+      this.textarea.value = getDataCallback();
+      this.toggleVisibility();
+    });
+  }
 
-    show(data) {
-        this.textarea.value = data;
-        this.toggleVisibility();
-    }
+  show(data) {
+    this.textarea.value = data;
+    this.toggleVisibility();
+  }
 }
 
 class LoadModal extends Modal {
-    constructor() {
-        super(document.getElementById('load_container'));
-        this.textarea = document.getElementById('load_textarea');
-        this.onLoad = (data) => {};
-        document.getElementById('load_ok').addEventListener('click', () => {
-            this.onLoad(this.textarea.value);
-            this.toggleVisibility();
-            this.textarea.value = "";
-        });
-        document.getElementById('load_cancel').addEventListener('click', () => {
-            this.toggleVisibility();
-        });
-        document.getElementById('load').addEventListener('click', () => {
-            this.toggleVisibility();
-        });
-    }
+  constructor() {
+    super(document.getElementById('load_container'));
+    this.textarea = document.getElementById('load_textarea');
+    this.onLoad = (data) => {};
+    document.getElementById('load_ok').addEventListener('click', () => {
+      this.onLoad(this.textarea.value);
+      this.toggleVisibility();
+      this.textarea.value = '';
+    });
+    document.getElementById('load_cancel').addEventListener('click', () => {
+      this.toggleVisibility();
+    });
+    document.getElementById('load').addEventListener('click', () => {
+      this.toggleVisibility();
+    });
+  }
 
-    show(data) {
-        this.textarea.value = data;
-        this.toggleVisibility();
-    }
+  show(data) {
+    this.textarea.value = data;
+    this.toggleVisibility();
+  }
 }
 
-export {DemoButtons,
-     EffectPicker,
-     KitPicker,
-     EffectSlider,
-     SwingSlider,
-     PitchSliders,
-    TempoInput, Playheads, Notes, PlayButton,
-    LoadModal, SaveModal, ResetButton };
+export {
+  DemoButtons,
+  EffectPicker,
+  EffectSlider,
+  KitPicker,
+  LoadModal,
+  Notes,
+  PitchSliders,
+  PlayButton,
+  Playheads,
+  ResetButton,
+  SaveModal,
+  SwingSlider,
+  TempoInput,
+};

--- a/archive/demos/shiny-drum-machine-ui.js
+++ b/archive/demos/shiny-drum-machine-ui.js
@@ -1,0 +1,272 @@
+class Slider {
+    constructor(element, opts = {}) {
+        this.element = element;
+        this.onchange = () => {};
+
+        element.addEventListener('input', () => {
+            this.onchange(this.value);
+        });
+
+        if(opts && opts.doubleClickValue) {
+            element.addEventListener('dblclick', () => {
+                this.value = opts.doubleClickValue;
+                this.onchange(this.value);
+            });
+        }
+    }
+
+    get value() {
+        return new Number(this.element.value) / 100;
+    }
+
+    set value(value) {
+        this.element.value = value * 100;
+    }
+}
+
+class EffectSlider extends Slider {
+    constructor(container=document) {
+        super(container.getElementById('effect_thumb'));
+    }
+}
+
+class SwingSlider extends Slider {
+    constructor(container=document) {
+        super(container.getElementById('swing_thumb'));
+    }
+}
+
+class PitchSliders {
+    constructor(container=document) {
+        this.sliders = {};
+        this.onPitchChange = (instrument, pitch) => {};
+        for(const el of container.querySelectorAll('[data-instrument][data-pitch]')) {
+            this.sliders[el.dataset.instrument] = new Slider(el, {doubleClickValue: 0.5});
+            this.sliders[el.dataset.instrument].onchange = (value) => {
+                this.onPitchChange(el.dataset.instrument, value);
+            };
+        }
+    }
+
+    setPitch(instrument, pitch) {
+        this.sliders[instrument].value = pitch;
+    }
+}
+
+class Button {
+    constructor(element, onclick = () => {}) {
+        this.element = element;
+        this.onclick = onclick;
+        element.addEventListener('click', (event) => this.onclick(event));
+    }
+
+    get state() {
+        return this.element.dataset.state;
+    }
+
+    set state(value) {
+        this.element.dataset.state = value;
+    }
+}
+
+class PlayButton extends Button {
+    constructor() {
+        super(document.getElementById('play'));
+    }
+}
+
+class ResetButton extends Button {
+    constructor() {
+        super(document.getElementById('reset'));
+    }
+}
+
+class Playheads {
+    constructor() {
+        this.current = 0;
+    }
+
+    drawPlayhead(index) {
+        // TODO: Refactor, replace with data attributes.
+        this.current = index;
+        const lastIndex = (index + 15) % 16;
+
+        const elNew = document.getElementById('LED_' + index);
+        const elOld = document.getElementById('LED_' + lastIndex);
+        
+        elNew.src = 'images/LED_on.png';
+        elOld.src = 'images/LED_off.png';
+    }
+
+    off() {
+        const el = document.getElementById(`LED_${this.current}`);
+        el.src = 'images/LED_off.png';
+    }
+}
+
+class DemoButtons {
+    constructor(container = document, onDemoClick = () => {}) {
+        this.buttons = {};
+        this.onDemoClick = onDemoClick;
+
+        const onButtonClick = (event) => {
+            this.onDemoClick(new Number(event.target.dataset.demo));
+        };
+
+        for(const element of container.querySelectorAll(`[data-demo]`)) {
+            const demoIndex = new Number(element.dataset.demo);
+            this.buttons[demoIndex] = new Button(element, onButtonClick);
+        }
+    }
+
+    markDemoAvailable(demoIndex) {
+        this.buttons[demoIndex].state = "loaded";
+    }
+}
+
+class Picker {
+    constructor(element) {
+        this.onSelect = (index) => {};
+        this.element = element;
+        this.element.addEventListener('change', () => this.onSelect(this.element.selectedIndex));
+    }
+
+    addOptions(names) {
+        for(const name of names) {
+            this.element.add(new Option(name));
+        }
+    }
+
+    select(index) {
+        this.element.selectedIndex = index;
+    }
+}
+
+class EffectPicker extends Picker {
+    constructor(container=document) {
+        super(container.getElementById('effectlist'));
+    }
+}
+
+class KitPicker extends Picker {
+    constructor(container=document) {
+        super(container.getElementById('kitlist'));
+    }
+}
+
+class TempoInput {
+    constructor({min, max, step}) {
+        this.labelElement = document.getElementById('tempo');
+        this.onTempoChange = (tempo) => {};
+
+        document.getElementById('tempoinc').addEventListener('click', () => {
+            this.value += this.step;
+            this.onTempoChange(this.value);
+        });
+
+        document.getElementById('tempodec').addEventListener('click', () => {
+            this.value -= this.step;
+            this.onTempoChange(this.value);
+        });
+
+        this.min = min;
+        this.max = max;
+        this.step = step;
+    }
+
+    set value(value) {
+        this.labelElement.innerText = Math.min(this.max, Math.max(this.min, value));
+    }
+
+    get value() {
+        return new Number(this.labelElement.innerText);
+    }
+}
+
+class Notes {
+    constructor() {
+        this.onClick = (instrument, rhythm) => {};
+
+        this.buttons = {};
+        for (const el of document.querySelectorAll(`[data-instrument][data-rhythm]`)) {
+            const instrument = el.dataset.instrument;
+            const rhythm = new Number(el.dataset.rhythm);
+
+            if(!this.buttons[instrument]) {
+                this.buttons[instrument] = {};
+            }
+
+            this.buttons[instrument][rhythm] = new Button(el);
+            this.buttons[instrument][rhythm].onclick = () => this.onClick(instrument, rhythm);
+        }
+    }
+
+    setNote(instrument, rhythmIndex, note) {
+        this.buttons[instrument][rhythmIndex].state = note;
+    }
+}
+
+class Modal {
+    constructor(element) {
+        this.element = element;
+    }
+
+    toggleVisibility() {
+        document.getElementById('pad').classList.toggle('active');
+        document.getElementById('params').classList.toggle('active');
+        document.getElementById('tools').classList.toggle('active');
+        this.element.classList.toggle('active');
+    }
+}
+
+class SaveModal extends Modal {
+    constructor(getDataCallback) {
+        super(document.getElementById('save_container'));
+        this.textarea = document.getElementById('save_textarea');
+        document.getElementById('save_ok').addEventListener('click', () => {
+            this.toggleVisibility();
+        });
+        document.getElementById('save').addEventListener('click', () => {
+            this.textarea.value = getDataCallback();
+            this.toggleVisibility();
+        });
+    }
+
+    show(data) {
+        this.textarea.value = data;
+        this.toggleVisibility();
+    }
+}
+
+class LoadModal extends Modal {
+    constructor() {
+        super(document.getElementById('load_container'));
+        this.textarea = document.getElementById('load_textarea');
+        this.onLoad = (data) => {};
+        document.getElementById('load_ok').addEventListener('click', () => {
+            this.onLoad(this.textarea.value);
+            this.toggleVisibility();
+            this.textarea.value = "";
+        });
+        document.getElementById('load_cancel').addEventListener('click', () => {
+            this.toggleVisibility();
+        });
+        document.getElementById('load').addEventListener('click', () => {
+            this.toggleVisibility();
+        });
+    }
+
+    show(data) {
+        this.textarea.value = data;
+        this.toggleVisibility();
+    }
+}
+
+export {DemoButtons,
+     EffectPicker,
+     KitPicker,
+     EffectSlider,
+     SwingSlider,
+     PitchSliders,
+    TempoInput, Playheads, Notes, PlayButton,
+    LoadModal, SaveModal, ResetButton };

--- a/archive/demos/shiny-drum-machine.html
+++ b/archive/demos/shiny-drum-machine.html
@@ -37,7 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
     <link href="https://fonts.googleapis.com/css2?family=Michroma&family=Open+Sans&display=swap" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href = "style/drummachine.css">
-    <script src="shiny-drum-machine.js"></script>
+    <script src="shiny-drum-machine.js" type="module"></script>
 
     <!-- Preload images of dynamic UI elements -->
     <link rel="preload" as="image" href="images/button_off.png">

--- a/archive/demos/shiny-drum-machine.html
+++ b/archive/demos/shiny-drum-machine.html
@@ -260,8 +260,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <section class='container active' id='tools'>
         <div class="row buttons_container">
             <span class='label' id='beatlabel'>Beat</span>
-            <input type='image' id='play' src='images/btn_play_loading.gif' alt='Play'>
-            <input type='image' id='stop' src='images/btn_stop.png' alt='Stop'>
+            <button id='play' class="btn play" alt='Toggle play'></button>
 
             <div class="button_group">    
                 <input type='image' id='save' src='images/btn_save.png' alt='Save'>
@@ -271,11 +270,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
             <span class='label' id='demolabel'>Demo</span>
             <div class="button_group">
-                <input type='image' id='demo1' src='images/btn_demo1_loading.gif' width='44' height='33' alt='Load demo 1'>
-                <input type='image' id='demo2' src='images/btn_demo2_loading.gif' width='44' height='33' alt='Load demo 2'>
-                <input type='image' id='demo3' src='images/btn_demo3_loading.gif' width='44' height='33' alt='Load demo 3'>
-                <input type='image' id='demo4' src='images/btn_demo4_loading.gif' width='44' height='33' alt='Load demo 4'>
-                <input type='image' id='demo5' src='images/btn_demo5_loading.gif' width='45' height='33' alt='Load demo 5'>
+                <button class='btn demo' data-demo='0' alt='Load demo 1'></button>
+                <button class='btn demo' data-demo='1' alt='Load demo 2'></button>
+                <button class='btn demo' data-demo='2' alt='Load demo 3'></button>
+                <button class='btn demo' data-demo='3' alt='Load demo 4'></button>
+                <button class='btn demo' data-demo='4' alt='Load demo 5'></button>
             </div>
         </div>
     </section>

--- a/archive/demos/shiny-drum-machine.html
+++ b/archive/demos/shiny-drum-machine.html
@@ -52,117 +52,117 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <section class='container active' id='pad'>
         <div class='buttons_row'>
             <span class='label'>Tom 1</span>
-            <input type='image' id='Tom1_0' class='btn' src='images/button_off.png' alt='Toggle Tom 1 on beat 1'>
-            <input type='image' id='Tom1_1' class='btn' src='images/button_off.png' alt='Toggle Tom 1 on beat 2'>
-            <input type='image' id='Tom1_2' class='btn' src='images/button_off.png' alt='Toggle Tom 1 on beat 3'>
-            <input type='image' id='Tom1_3' class='btn' src='images/button_off.png' alt='Toggle Tom 1 on beat 4'>
-            <input type='image' id='Tom1_4' class='btn' src='images/button_off.png' alt='Toggle Tom 1 on beat 5'>
-            <input type='image' id='Tom1_5' class='btn' src='images/button_off.png' alt='Toggle Tom 1 on beat 6'>
-            <input type='image' id='Tom1_6' class='btn' src='images/button_off.png' alt='Toggle Tom 1 on beat 7'>
-            <input type='image' id='Tom1_7' class='btn' src='images/button_off.png' alt='Toggle Tom 1 on beat 8'>
-            <input type='image' id='Tom1_8' class='btn' src='images/button_off.png' alt='Toggle Tom 1 on beat 9'>
-            <input type='image' id='Tom1_9' class='btn' src='images/button_off.png' alt='Toggle Tom 1 on beat 10'>
-            <input type='image' id='Tom1_10' class='btn' src='images/button_off.png' alt='Toggle Tom 1 on beat 11'>
-            <input type='image' id='Tom1_11' class='btn' src='images/button_off.png' alt='Toggle Tom 1 on beat 12'>
-            <input type='image' id='Tom1_12' class='btn' src='images/button_off.png' alt='Toggle Tom 1 on beat 13'>
-            <input type='image' id='Tom1_13' class='btn' src='images/button_off.png' alt='Toggle Tom 1 on beat 14'>
-            <input type='image' id='Tom1_14' class='btn' src='images/button_off.png' alt='Toggle Tom 1 on beat 15'>
-            <input type='image' id='Tom1_15' class='btn' src='images/button_off.png' alt='Toggle Tom 1 on beat 16'>
+            <button data-instrument='Tom1' data-rhythm='0' class='btn note' alt='Toggle Tom 1 on beat 1'></button>
+            <button data-instrument='Tom1' data-rhythm='1' class='btn note' alt='Toggle Tom 1 on beat 2'></button>
+            <button data-instrument='Tom1' data-rhythm='2' class='btn note' alt='Toggle Tom 1 on beat 3'></button>
+            <button data-instrument='Tom1' data-rhythm='3' class='btn note' alt='Toggle Tom 1 on beat 4'></button>
+            <button data-instrument='Tom1' data-rhythm='4' class='btn note' alt='Toggle Tom 1 on beat 5'></button>
+            <button data-instrument='Tom1' data-rhythm='5' class='btn note' alt='Toggle Tom 1 on beat 6'></button>
+            <button data-instrument='Tom1' data-rhythm='6' class='btn note' alt='Toggle Tom 1 on beat 7'></button>
+            <button data-instrument='Tom1' data-rhythm='7' class='btn note' alt='Toggle Tom 1 on beat 8'></button>
+            <button data-instrument='Tom1' data-rhythm='8' class='btn note' alt='Toggle Tom 1 on beat 9'></button>
+            <button data-instrument='Tom1' data-rhythm='9' class='btn note' alt='Toggle Tom 1 on beat 10'></button>
+            <button data-instrument='Tom1' data-rhythm='10' class='btn note' alt='Toggle Tom 1 on beat 11'></button>
+            <button data-instrument='Tom1' data-rhythm='11' class='btn note' alt='Toggle Tom 1 on beat 12'></button>
+            <button data-instrument='Tom1' data-rhythm='12' class='btn note' alt='Toggle Tom 1 on beat 13'></button>
+            <button data-instrument='Tom1' data-rhythm='13' class='btn note' alt='Toggle Tom 1 on beat 14'></button>
+            <button data-instrument='Tom1' data-rhythm='14' class='btn note' alt='Toggle Tom 1 on beat 15'></button>
+            <button data-instrument='Tom1' data-rhythm='15' class='btn note' alt='Toggle Tom 1 on beat 16'></button>
         </div>
         <div class='buttons_row'>
             <span class='label'>Tom 2</span>
-            <input type='image' id='Tom2_0' class='btn' src='images/button_off.png' alt='Toggle Tom 2 on beat 1'>
-            <input type='image' id='Tom2_1' class='btn' src='images/button_off.png' alt='Toggle Tom 2 on beat 2'>
-            <input type='image' id='Tom2_2' class='btn' src='images/button_off.png' alt='Toggle Tom 2 on beat 3'>
-            <input type='image' id='Tom2_3' class='btn' src='images/button_off.png' alt='Toggle Tom 2 on beat 4'>
-            <input type='image' id='Tom2_4' class='btn' src='images/button_off.png' alt='Toggle Tom 2 on beat 5'>
-            <input type='image' id='Tom2_5' class='btn' src='images/button_off.png' alt='Toggle Tom 2 on beat 6'>
-            <input type='image' id='Tom2_6' class='btn' src='images/button_off.png' alt='Toggle Tom 2 on beat 7'>
-            <input type='image' id='Tom2_7' class='btn' src='images/button_off.png' alt='Toggle Tom 2 on beat 8'>
-            <input type='image' id='Tom2_8' class='btn' src='images/button_off.png' alt='Toggle Tom 2 on beat 9'>
-            <input type='image' id='Tom2_9' class='btn' src='images/button_off.png' alt='Toggle Tom 2 on beat 10'>
-            <input type='image' id='Tom2_10' class='btn' src='images/button_off.png' alt='Toggle Tom 2 on beat 11'>
-            <input type='image' id='Tom2_11' class='btn' src='images/button_off.png' alt='Toggle Tom 2 on beat 12'>
-            <input type='image' id='Tom2_12' class='btn' src='images/button_off.png' alt='Toggle Tom 2 on beat 13'>
-            <input type='image' id='Tom2_13' class='btn' src='images/button_off.png' alt='Toggle Tom 2 on beat 14'>
-            <input type='image' id='Tom2_14' class='btn' src='images/button_off.png' alt='Toggle Tom 2 on beat 15'>
-            <input type='image' id='Tom2_15' class='btn' src='images/button_off.png' alt='Toggle Tom 2 on beat 16'>
+            <button data-instrument='Tom2' data-rhythm='0' class='btn note' alt='Toggle Tom 2 on beat 1'></button>
+            <button data-instrument='Tom2' data-rhythm='1' class='btn note' alt='Toggle Tom 2 on beat 2'></button>
+            <button data-instrument='Tom2' data-rhythm='2' class='btn note' alt='Toggle Tom 2 on beat 3'></button>
+            <button data-instrument='Tom2' data-rhythm='3' class='btn note' alt='Toggle Tom 2 on beat 4'></button>
+            <button data-instrument='Tom2' data-rhythm='4' class='btn note' alt='Toggle Tom 2 on beat 5'></button>
+            <button data-instrument='Tom2' data-rhythm='5' class='btn note' alt='Toggle Tom 2 on beat 6'></button>
+            <button data-instrument='Tom2' data-rhythm='6' class='btn note' alt='Toggle Tom 2 on beat 7'></button>
+            <button data-instrument='Tom2' data-rhythm='7' class='btn note' alt='Toggle Tom 2 on beat 8'></button>
+            <button data-instrument='Tom2' data-rhythm='8' class='btn note' alt='Toggle Tom 2 on beat 9'></button>
+            <button data-instrument='Tom2' data-rhythm='9' class='btn note' alt='Toggle Tom 2 on beat 10'></button>
+            <button data-instrument='Tom2' data-rhythm='10' class='btn note' alt='Toggle Tom 2 on beat 11'></button>
+            <button data-instrument='Tom2' data-rhythm='11' class='btn note' alt='Toggle Tom 2 on beat 12'></button>
+            <button data-instrument='Tom2' data-rhythm='12' class='btn note' alt='Toggle Tom 2 on beat 13'></button>
+            <button data-instrument='Tom2' data-rhythm='13' class='btn note' alt='Toggle Tom 2 on beat 14'></button>
+            <button data-instrument='Tom2' data-rhythm='14' class='btn note' alt='Toggle Tom 2 on beat 15'></button>
+            <button data-instrument='Tom2' data-rhythm='15' class='btn note' alt='Toggle Tom 2 on beat 16'></button>
         </div>
         <div class='buttons_row'>
             <span class='label'>Tom 3</span>
-            <input type='image' id='Tom3_0' class='btn' src='images/button_off.png' alt='Toggle Tom 3 on beat 1'>
-            <input type='image' id='Tom3_1' class='btn' src='images/button_off.png' alt='Toggle Tom 3 on beat 2'>
-            <input type='image' id='Tom3_2' class='btn' src='images/button_off.png' alt='Toggle Tom 3 on beat 3'>
-            <input type='image' id='Tom3_3' class='btn' src='images/button_off.png' alt='Toggle Tom 3 on beat 4'>
-            <input type='image' id='Tom3_4' class='btn' src='images/button_off.png' alt='Toggle Tom 3 on beat 5'>
-            <input type='image' id='Tom3_5' class='btn' src='images/button_off.png' alt='Toggle Tom 3 on beat 6'>
-            <input type='image' id='Tom3_6' class='btn' src='images/button_off.png' alt='Toggle Tom 3 on beat 7'>
-            <input type='image' id='Tom3_7' class='btn' src='images/button_off.png' alt='Toggle Tom 3 on beat 8'>
-            <input type='image' id='Tom3_8' class='btn' src='images/button_off.png' alt='Toggle Tom 3 on beat 9'>
-            <input type='image' id='Tom3_9' class='btn' src='images/button_off.png' alt='Toggle Tom 3 on beat 10'>
-            <input type='image' id='Tom3_10' class='btn' src='images/button_off.png' alt='Toggle Tom 3 on beat 11'>
-            <input type='image' id='Tom3_11' class='btn' src='images/button_off.png' alt='Toggle Tom 3 on beat 12'>
-            <input type='image' id='Tom3_12' class='btn' src='images/button_off.png' alt='Toggle Tom 3 on beat 13'>
-            <input type='image' id='Tom3_13' class='btn' src='images/button_off.png' alt='Toggle Tom 3 on beat 14'>
-            <input type='image' id='Tom3_14' class='btn' src='images/button_off.png' alt='Toggle Tom 3 on beat 15'>
-            <input type='image' id='Tom3_15' class='btn' src='images/button_off.png' alt='Toggle Tom 3 on beat 16'>
+            <button data-instrument='Tom3' data-rhythm='0' class='btn note' alt='Toggle Tom 3 on beat 1'></button>
+            <button data-instrument='Tom3' data-rhythm='1' class='btn note' alt='Toggle Tom 3 on beat 2'></button>
+            <button data-instrument='Tom3' data-rhythm='2' class='btn note' alt='Toggle Tom 3 on beat 3'></button>
+            <button data-instrument='Tom3' data-rhythm='3' class='btn note' alt='Toggle Tom 3 on beat 4'></button>
+            <button data-instrument='Tom3' data-rhythm='4' class='btn note' alt='Toggle Tom 3 on beat 5'></button>
+            <button data-instrument='Tom3' data-rhythm='5' class='btn note' alt='Toggle Tom 3 on beat 6'></button>
+            <button data-instrument='Tom3' data-rhythm='6' class='btn note' alt='Toggle Tom 3 on beat 7'></button>
+            <button data-instrument='Tom3' data-rhythm='7' class='btn note' alt='Toggle Tom 3 on beat 8'></button>
+            <button data-instrument='Tom3' data-rhythm='8' class='btn note' alt='Toggle Tom 3 on beat 9'></button>
+            <button data-instrument='Tom3' data-rhythm='9' class='btn note' alt='Toggle Tom 3 on beat 10'></button>
+            <button data-instrument='Tom3' data-rhythm='10' class='btn note' alt='Toggle Tom 3 on beat 11'></button>
+            <button data-instrument='Tom3' data-rhythm='11' class='btn note' alt='Toggle Tom 3 on beat 12'></button>
+            <button data-instrument='Tom3' data-rhythm='12' class='btn note' alt='Toggle Tom 3 on beat 13'></button>
+            <button data-instrument='Tom3' data-rhythm='13' class='btn note' alt='Toggle Tom 3 on beat 14'></button>
+            <button data-instrument='Tom3' data-rhythm='14' class='btn note' alt='Toggle Tom 3 on beat 15'></button>
+            <button data-instrument='Tom3' data-rhythm='15' class='btn note' alt='Toggle Tom 3 on beat 16'></button>
         </div>
         <div class='buttons_row'>
             <span class='label'>Hi-Hat</span>
-            <input type='image' id='HiHat_0' class='btn' src='images/button_off.png' alt='Toggle Hi-Hat on beat 1'>
-            <input type='image' id='HiHat_1' class='btn' src='images/button_off.png' alt='Toggle Hi-Hat on beat 2'>
-            <input type='image' id='HiHat_2' class='btn' src='images/button_off.png' alt='Toggle Hi-Hat on beat 3'>
-            <input type='image' id='HiHat_3' class='btn' src='images/button_off.png' alt='Toggle Hi-Hat on beat 4'>
-            <input type='image' id='HiHat_4' class='btn' src='images/button_off.png' alt='Toggle Hi-Hat on beat 5'>
-            <input type='image' id='HiHat_5' class='btn' src='images/button_off.png' alt='Toggle Hi-Hat on beat 6'>
-            <input type='image' id='HiHat_6' class='btn' src='images/button_off.png' alt='Toggle Hi-Hat on beat 7'>
-            <input type='image' id='HiHat_7' class='btn' src='images/button_off.png' alt='Toggle Hi-Hat on beat 8'>
-            <input type='image' id='HiHat_8' class='btn' src='images/button_off.png' alt='Toggle Hi-Hat on beat 9'>
-            <input type='image' id='HiHat_9' class='btn' src='images/button_off.png' alt='Toggle Hi-Hat on beat 10'>
-            <input type='image' id='HiHat_10' class='btn' src='images/button_off.png' alt='Toggle Hi-Hat on beat 11'>
-            <input type='image' id='HiHat_11' class='btn' src='images/button_off.png' alt='Toggle Hi-Hat on beat 12'>
-            <input type='image' id='HiHat_12' class='btn' src='images/button_off.png' alt='Toggle Hi-Hat on beat 13'>
-            <input type='image' id='HiHat_13' class='btn' src='images/button_off.png' alt='Toggle Hi-Hat on beat 14'>
-            <input type='image' id='HiHat_14' class='btn' src='images/button_off.png' alt='Toggle Hi-Hat on beat 15'>
-            <input type='image' id='HiHat_15' class='btn' src='images/button_off.png' alt='Toggle Hi-Hat on beat 16'>
+            <button data-instrument='HiHat' data-rhythm='0' class='btn note' alt='Toggle Hi-Hat on beat 1'></button>
+            <button data-instrument='HiHat' data-rhythm='1' class='btn note' alt='Toggle Hi-Hat on beat 2'></button>
+            <button data-instrument='HiHat' data-rhythm='2' class='btn note' alt='Toggle Hi-Hat on beat 3'></button>
+            <button data-instrument='HiHat' data-rhythm='3' class='btn note' alt='Toggle Hi-Hat on beat 4'></button>
+            <button data-instrument='HiHat' data-rhythm='4' class='btn note' alt='Toggle Hi-Hat on beat 5'></button>
+            <button data-instrument='HiHat' data-rhythm='5' class='btn note' alt='Toggle Hi-Hat on beat 6'></button>
+            <button data-instrument='HiHat' data-rhythm='6' class='btn note' alt='Toggle Hi-Hat on beat 7'></button>
+            <button data-instrument='HiHat' data-rhythm='7' class='btn note' alt='Toggle Hi-Hat on beat 8'></button>
+            <button data-instrument='HiHat' data-rhythm='8' class='btn note' alt='Toggle Hi-Hat on beat 9'></button>
+            <button data-instrument='HiHat' data-rhythm='9' class='btn note' alt='Toggle Hi-Hat on beat 10'></button>
+            <button data-instrument='HiHat' data-rhythm='10' class='btn note' alt='Toggle Hi-Hat on beat 11'></button>
+            <button data-instrument='HiHat' data-rhythm='11' class='btn note' alt='Toggle Hi-Hat on beat 12'></button>
+            <button data-instrument='HiHat' data-rhythm='12' class='btn note' alt='Toggle Hi-Hat on beat 13'></button>
+            <button data-instrument='HiHat' data-rhythm='13' class='btn note' alt='Toggle Hi-Hat on beat 14'></button>
+            <button data-instrument='HiHat' data-rhythm='14' class='btn note' alt='Toggle Hi-Hat on beat 15'></button>
+            <button data-instrument='HiHat' data-rhythm='15' class='btn note' alt='Toggle Hi-Hat on beat 16'></button>
         </div>
         <div class='buttons_row'>
             <span class='label'>Snare</span>
-            <input type='image' id='Snare_0' class='btn' src='images/button_off.png' alt='Toggle Snare on beat 1'>
-            <input type='image' id='Snare_1' class='btn' src='images/button_off.png' alt='Toggle Snare on beat 2'>
-            <input type='image' id='Snare_2' class='btn' src='images/button_off.png' alt='Toggle Snare on beat 3'>
-            <input type='image' id='Snare_3' class='btn' src='images/button_off.png' alt='Toggle Snare on beat 4'>
-            <input type='image' id='Snare_4' class='btn' src='images/button_off.png' alt='Toggle Snare on beat 5'>
-            <input type='image' id='Snare_5' class='btn' src='images/button_off.png' alt='Toggle Snare on beat 6'>
-            <input type='image' id='Snare_6' class='btn' src='images/button_off.png' alt='Toggle Snare on beat 7'>
-            <input type='image' id='Snare_7' class='btn' src='images/button_off.png' alt='Toggle Snare on beat 8'>
-            <input type='image' id='Snare_8' class='btn' src='images/button_off.png' alt='Toggle Snare on beat 9'>
-            <input type='image' id='Snare_9' class='btn' src='images/button_off.png' alt='Toggle Snare on beat 10'>
-            <input type='image' id='Snare_10' class='btn' src='images/button_off.png' alt='Toggle Snare on beat 11'>
-            <input type='image' id='Snare_11' class='btn' src='images/button_off.png' alt='Toggle Snare on beat 12'>
-            <input type='image' id='Snare_12' class='btn' src='images/button_off.png' alt='Toggle Snare on beat 13'>
-            <input type='image' id='Snare_13' class='btn' src='images/button_off.png' alt='Toggle Snare on beat 14'>
-            <input type='image' id='Snare_14' class='btn' src='images/button_off.png' alt='Toggle Snare on beat 15'>
-            <input type='image' id='Snare_15' class='btn' src='images/button_off.png' alt='Toggle Snare on beat 16'>
+            <button data-instrument='Snare' data-rhythm='0' class='btn note' alt='Toggle Snare on beat 1'></button>
+            <button data-instrument='Snare' data-rhythm='1' class='btn note' alt='Toggle Snare on beat 2'></button>
+            <button data-instrument='Snare' data-rhythm='2' class='btn note' alt='Toggle Snare on beat 3'></button>
+            <button data-instrument='Snare' data-rhythm='3' class='btn note' alt='Toggle Snare on beat 4'></button>
+            <button data-instrument='Snare' data-rhythm='4' class='btn note' alt='Toggle Snare on beat 5'></button>
+            <button data-instrument='Snare' data-rhythm='5' class='btn note' alt='Toggle Snare on beat 6'></button>
+            <button data-instrument='Snare' data-rhythm='6' class='btn note' alt='Toggle Snare on beat 7'></button>
+            <button data-instrument='Snare' data-rhythm='7' class='btn note' alt='Toggle Snare on beat 8'></button>
+            <button data-instrument='Snare' data-rhythm='8' class='btn note' alt='Toggle Snare on beat 9'></button>
+            <button data-instrument='Snare' data-rhythm='9' class='btn note' alt='Toggle Snare on beat 10'></button>
+            <button data-instrument='Snare' data-rhythm='10' class='btn note' alt='Toggle Snare on beat 11'></button>
+            <button data-instrument='Snare' data-rhythm='11' class='btn note' alt='Toggle Snare on beat 12'></button>
+            <button data-instrument='Snare' data-rhythm='12' class='btn note' alt='Toggle Snare on beat 13'></button>
+            <button data-instrument='Snare' data-rhythm='13' class='btn note' alt='Toggle Snare on beat 14'></button>
+            <button data-instrument='Snare' data-rhythm='14' class='btn note' alt='Toggle Snare on beat 15'></button>
+            <button data-instrument='Snare' data-rhythm='15' class='btn note' alt='Toggle Snare on beat 16'></button>
         </div>
         <div class='buttons_row'>
             <span class='label'>Kick</span>
-            <input type='image' id='Kick_0' class='btn' src='images/button_off.png' alt='Toggle Kick on beat 1'>
-            <input type='image' id='Kick_1' class='btn' src='images/button_off.png' alt='Toggle Kick on beat 2'>
-            <input type='image' id='Kick_2' class='btn' src='images/button_off.png' alt='Toggle Kick on beat 3'>
-            <input type='image' id='Kick_3' class='btn' src='images/button_off.png' alt='Toggle Kick on beat 4'>
-            <input type='image' id='Kick_4' class='btn' src='images/button_off.png' alt='Toggle Kick on beat 5'>
-            <input type='image' id='Kick_5' class='btn' src='images/button_off.png' alt='Toggle Kick on beat 6'>
-            <input type='image' id='Kick_6' class='btn' src='images/button_off.png' alt='Toggle Kick on beat 7'>
-            <input type='image' id='Kick_7' class='btn' src='images/button_off.png' alt='Toggle Kick on beat 8'>
-            <input type='image' id='Kick_8' class='btn' src='images/button_off.png' alt='Toggle Kick on beat 9'>
-            <input type='image' id='Kick_9' class='btn' src='images/button_off.png' alt='Toggle Kick on beat 10'>
-            <input type='image' id='Kick_10' class='btn' src='images/button_off.png' alt='Toggle Kick on beat 11'>
-            <input type='image' id='Kick_11' class='btn' src='images/button_off.png' alt='Toggle Kick on beat 12'>
-            <input type='image' id='Kick_12' class='btn' src='images/button_off.png' alt='Toggle Kick on beat 13'>
-            <input type='image' id='Kick_13' class='btn' src='images/button_off.png' alt='Toggle Kick on beat 14'>
-            <input type='image' id='Kick_14' class='btn' src='images/button_off.png' alt='Toggle Kick on beat 15'>
-            <input type='image' id='Kick_15' class='btn' src='images/button_off.png' alt='Toggle Kick on beat 16'>
+            <button data-instrument='Kick' data-rhythm='0' class='btn note' alt='Toggle Kick on beat 1'></button>
+            <button data-instrument='Kick' data-rhythm='1' class='btn note' alt='Toggle Kick on beat 2'></button>
+            <button data-instrument='Kick' data-rhythm='2' class='btn note' alt='Toggle Kick on beat 3'></button>
+            <button data-instrument='Kick' data-rhythm='3' class='btn note' alt='Toggle Kick on beat 4'></button>
+            <button data-instrument='Kick' data-rhythm='4' class='btn note' alt='Toggle Kick on beat 5'></button>
+            <button data-instrument='Kick' data-rhythm='5' class='btn note' alt='Toggle Kick on beat 6'></button>
+            <button data-instrument='Kick' data-rhythm='6' class='btn note' alt='Toggle Kick on beat 7'></button>
+            <button data-instrument='Kick' data-rhythm='7' class='btn note' alt='Toggle Kick on beat 8'></button>
+            <button data-instrument='Kick' data-rhythm='8' class='btn note' alt='Toggle Kick on beat 9'></button>
+            <button data-instrument='Kick' data-rhythm='9' class='btn note' alt='Toggle Kick on beat 10'></button>
+            <button data-instrument='Kick' data-rhythm='10' class='btn note' alt='Toggle Kick on beat 11'></button>
+            <button data-instrument='Kick' data-rhythm='11' class='btn note' alt='Toggle Kick on beat 12'></button>
+            <button data-instrument='Kick' data-rhythm='12' class='btn note' alt='Toggle Kick on beat 13'></button>
+            <button data-instrument='Kick' data-rhythm='13' class='btn note' alt='Toggle Kick on beat 14'></button>
+            <button data-instrument='Kick' data-rhythm='14' class='btn note' alt='Toggle Kick on beat 15'></button>
+            <button data-instrument='Kick' data-rhythm='15' class='btn note' alt='Toggle Kick on beat 16'></button>
         </div>
         <div class='buttons_row' id='LED_row'>
             <span class='label'></span>

--- a/archive/demos/shiny-drum-machine.html
+++ b/archive/demos/shiny-drum-machine.html
@@ -211,45 +211,45 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 </div>
             </div>
             <div class='vrule'></div>
-            <div class='slider_container' id='effect_container'>
+            <div class='slider_container'>
                 <input type='range' class='vertical' id='effect_thumb'>
                 <label class='slider_label' for='effect_thumb'>
                     Effect Level
                 </label>
             </div>
             <div class='vrule'></div>
-            <div class='slider_container' id='kick_container'>
-                <input type='range' class='vertical' id='kick_thumb'>
+            <div class='slider_container'>
+                <input type='range' class='vertical' id='kick_thumb' data-instrument="Kick" data-pitch>
                 <label class='slider_label' for='kick_thumb'>
                     Kick Pitch
                 </label>
             </div>
-            <div class='slider_container' id='snare_container'>
-                <input type='range' class='vertical' id='snare_thumb'>
+            <div class='slider_container'>
+                <input type='range' class='vertical' id='snare_thumb' data-instrument="Snare" data-pitch>
                 <label class='slider_label' for='snare_thumb'>
                     Snare Pitch
                 </label>
             </div>
-            <div class='slider_container' id='hihat_container'>
-                <input type='range' class='vertical' id='hihat_thumb'>
+            <div class='slider_container'>
+                <input type='range' class='vertical' id='hihat_thumb' data-instrument="HiHat" data-pitch>
                 <label class='slider_label' for='hihat_thumb'>
                     Hi-Hat Pitch
                 </label>
             </div>
-            <div class='slider_container' id='tom1_container'>
-                <input type='range' class='vertical' id='tom1_thumb'>
+            <div class='slider_container'>
+                <input type='range' class='vertical' id='tom1_thumb' data-instrument="Tom1" data-pitch>
                 <label class='slider_label' for='tom1_thumb'>
                     Tom 1 Pitch
                 </label>
             </div>
-            <div class='slider_container' id='tom2_container'>
-                <input type='range' class='vertical' id='tom2_thumb'>
+            <div class='slider_container'>
+                <input type='range' class='vertical' id='tom2_thumb' data-instrument="Tom2" data-pitch>
                 <label class='slider_label' for='tom2_thumb'>
                     Tom 2 Pitch
                 </label>
             </div>
-            <div class='slider_container' id='tom3_container'>
-                <input type='range' class='vertical' id='tom3_thumb'>
+            <div class='slider_container'>
+                <input type='range' class='vertical' id='tom3_thumb' data-instrument="Tom3" data-pitch>
                 <label class='slider_label' for='tom3_thumb'>
                     Tom 3 Pitch
                 </label>

--- a/archive/demos/shiny-drum-machine.js
+++ b/archive/demos/shiny-drum-machine.js
@@ -1,5 +1,9 @@
-import { RESET_BEAT, DEMO_BEATS, INSTRUMENTS, KIT_DATA, IMPULSE_RESPONSE_DATA, freeze, clone } from "./shiny-drum-machine-data.js";
-import { DemoButtons, EffectPicker, KitPicker, EffectSlider, SwingSlider, PitchSliders, TempoInput, Playheads, Notes, SaveModal, LoadModal, ResetButton, PlayButton } from './shiny-drum-machine-ui.js';
+import {RESET_BEAT, DEMO_BEATS, INSTRUMENTS, KIT_DATA, IMPULSE_RESPONSE_DATA,
+  freeze, clone} from './shiny-drum-machine-data.js';
+
+import {DemoButtons, EffectPicker, KitPicker, EffectSlider, SwingSlider,
+  PitchSliders, TempoInput, Playheads, Notes, SaveModal, LoadModal,
+  ResetButton, PlayButton} from './shiny-drum-machine-ui.js';
 
 
 // Events
@@ -40,438 +44,439 @@ let KITS;
 let impulseResponses;
 
 const ui = Object.seal({
-    effectPicker: null,
-    kitPicker: null,
-    demoButtons: null,
-    swingSlider: null,
-    effectSlider: null,
-    pitchSliders: null,
-    tempoInput: null,
-    notes: null,
-    playButton: null,
-    resetButton: null,
-    playheads: null,
-    modal: {
-        save: null,
-        load: null,
-    },
+  effectPicker: null,
+  kitPicker: null,
+  demoButtons: null,
+  swingSlider: null,
+  effectSlider: null,
+  pitchSliders: null,
+  tempoInput: null,
+  notes: null,
+  playButton: null,
+  resetButton: null,
+  playheads: null,
+  modal: {
+    save: null,
+    load: null,
+  },
 });
 
 class Kit {
-    constructor(id, prettyName) {
-        this.id = id;
-        this.prettyName = prettyName;
-        this.buffer = {};
-    }
+  constructor(id, prettyName) {
+    this.id = id;
+    this.prettyName = prettyName;
+    this.buffer = {};
+  }
 
-    getSampleUrl(instrumentName) {
-        return `sounds/drum-samples/${this.id}/${instrumentName.toLowerCase()}.wav`;
-    }
+  getSampleUrl(instrumentName) {
+    return `sounds/drum-samples/${this.id}/${instrumentName.toLowerCase()}.wav`;
+  }
 
-    load() {
-        const instrumentPromises = INSTRUMENTS.map(instrument => this.loadSample(instrument.name));
-        const promise = Promise.all(instrumentPromises).then(() => null);
-        // Return original Promise on subsequent load calls to avoid duplicate loads.
-        this.load = () => promise;
-        return promise;
-    }
+  load() {
+    const instrumentPromises = INSTRUMENTS.map((instrument) => this.loadSample(instrument.name));
+    const promise = Promise.all(instrumentPromises).then(() => null);
+    // Return original Promise on subsequent load calls to avoid duplicate loads.
+    this.load = () => promise;
+    return promise;
+  }
 
-    async loadSample(instrumentName) {
-        const request = new Request(this.getSampleUrl(instrumentName));
-        const response = await fetch(request);
-        const responseBuffer = await response.arrayBuffer();
+  async loadSample(instrumentName) {
+    const request = new Request(this.getSampleUrl(instrumentName));
+    const response = await fetch(request);
+    const responseBuffer = await response.arrayBuffer();
 
-        // TODO: Migrate to Promise-syntax once Safari supports it.
-        return new Promise((resolve) => {
-            context.decodeAudioData(responseBuffer, (buffer) => {
-                this.buffer[instrumentName] = buffer;
-                resolve();
-            });
-        });
-    }
+    // TODO(#226): Migrate to Promise-syntax once Safari supports it.
+    return new Promise((resolve) => {
+      context.decodeAudioData(responseBuffer, (buffer) => {
+        this.buffer[instrumentName] = buffer;
+        resolve();
+      });
+    });
+  }
 }
 
 
 class ImpulseResponse {
-    constructor(data, index) {
-        this.name = data.name;
-        this.url = data.url;
-        this.index = index;
-        this.buffer = undefined;
+  constructor(data, index) {
+    this.name = data.name;
+    this.url = data.url;
+    this.index = index;
+    this.buffer = undefined;
+  }
+
+  async load() {
+    if (!this.url) {
+      return; // "No effect" instance has empty URL.
     }
 
-    async load() {
-        if (!this.url) {
-            return; // "No effect" instance has empty URL.
-        }
+    const request = new Request(this.url);
+    const response = await fetch(request);
+    const responseBuffer = await response.arrayBuffer();
 
-        const request = new Request(this.url);
-        const response = await fetch(request);
-        const responseBuffer = await response.arrayBuffer();
+    // TODO(#226): Migrate to Promise-syntax once Safari supports it.
+    const result = new Promise((resolve) => {
+      context.decodeAudioData(responseBuffer, (buffer) => {
+        this.buffer = buffer;
+        resolve();
+      });
+    });
 
-        // TODO: Migrate to Promise-syntax once Safari supports it.
-        const result = new Promise((resolve) => {
-            context.decodeAudioData(responseBuffer, (buffer) => {
-                this.buffer = buffer;
-                resolve();
-            });
-        });
-
-        // Return original Promise on subsequent load calls to avoid duplicate loads.
-        this.load = () => result;
-        return result;
-    }
+    // Return original Promise on subsequent load calls to avoid duplicate loads.
+    this.load = () => result;
+    return result;
+  }
 }
 
 function loadDemos(onDemoLoaded) {
-    for (let demoIndex = 0; demoIndex < 5; demoIndex++) {
-        const demo = DEMO_BEATS[demoIndex];
-        const effect = impulseResponses[demo.effectIndex];
-        const kit = KITS[demo.kitIndex];
+  for (let demoIndex = 0; demoIndex < 5; demoIndex++) {
+    const demo = DEMO_BEATS[demoIndex];
+    const effect = impulseResponses[demo.effectIndex];
+    const kit = KITS[demo.kitIndex];
 
-        Promise.all([
-            effect.load(),
-            kit.load(),
-        ]).then(() => onDemoLoaded(demoIndex));
-    }
+    Promise.all([
+      effect.load(),
+      kit.load(),
+    ]).then(() => onDemoLoaded(demoIndex));
+  }
 }
 
 function loadAssets() {
-    // Note that any assets which have previously started loading will be skipped over.
-    for (const kit of KITS) {
-        kit.load();
-    }
+  // Note that any assets which have previously started loading will be skipped over.
+  for (const kit of KITS) {
+    kit.load();
+  }
 
-    for (const impulseResponse of impulseResponses) {
-        impulseResponse.load();
-    }
+  for (const impulseResponse of impulseResponses) {
+    impulseResponse.load();
+  }
 }
 
 function getCurrentKit() {
-    return KITS[theBeat.kitIndex];
+  return KITS[theBeat.kitIndex];
 }
 
 // This gets rid of the loading spinner in each of the demo buttons.
 function onDemoLoaded(demoIndex) {
-    ui.demoButtons.markDemoAvailable(demoIndex)
+  ui.demoButtons.markDemoAvailable(demoIndex);
 
-    // Enable play button and assign it to demo 2.
-    if (demoIndex == 1) {
-        // This gets rid of the loading spinner on the play button.
-        ui.playButton.state = "stopped";
-        loadBeat(DEMO_BEATS[1]);
-    }
+  // Enable play button and assign it to demo 2.
+  if (demoIndex == 1) {
+    // This gets rid of the loading spinner on the play button.
+    ui.playButton.state = 'stopped';
+    loadBeat(DEMO_BEATS[1]);
+  }
 }
 
 function init() {
-    impulseResponses = IMPULSE_RESPONSE_DATA.map((data, i) => new ImpulseResponse(data, i));
-    KITS = KIT_DATA.map(({ id, name }) => new Kit(id, name));
+  impulseResponses = IMPULSE_RESPONSE_DATA.map((data, i) => new ImpulseResponse(data, i));
+  KITS = KIT_DATA.map(({id, name}) => new Kit(id, name));
 
-    initControls();
+  initControls();
 
-    // Start loading the assets used by the presets first, in order of the presets.
-    // The callback gets rid of the loading spinner in each of the demo buttons.
-    loadDemos(onDemoLoaded);
+  // Start loading the assets used by the presets first, in order of the presets.
+  // The callback gets rid of the loading spinner in each of the demo buttons.
+  loadDemos(onDemoLoaded);
 
-    // Then load the remaining assets.
-    loadAssets();
+  // Then load the remaining assets.
+  loadAssets();
 
-    context = new AudioContext();
+  context = new AudioContext();
 
-    var finalMixNode;
-    if (context.createDynamicsCompressor) {
-        // Create a dynamics compressor to sweeten the overall mix.
-        compressor = context.createDynamicsCompressor();
-        compressor.connect(context.destination);
-        finalMixNode = compressor;
-    } else {
-        // No compressor available in this implementation.
-        finalMixNode = context.destination;
-    }
+  let finalMixNode;
+  if (context.createDynamicsCompressor) {
+    // Create a dynamics compressor to sweeten the overall mix.
+    compressor = context.createDynamicsCompressor();
+    compressor.connect(context.destination);
+    finalMixNode = compressor;
+  } else {
+    // No compressor available in this implementation.
+    finalMixNode = context.destination;
+  }
 
-    // Create master volume.
-    masterGainNode = context.createGain();
-    masterGainNode.gain.value = 0.7; // reduce overall volume to avoid clipping
-    masterGainNode.connect(finalMixNode);
+  // Create master volume.
+  masterGainNode = context.createGain();
+  masterGainNode.gain.value = 0.7; // reduce overall volume to avoid clipping
+  masterGainNode.connect(finalMixNode);
 
-    // Create effect volume.
-    effectLevelNode = context.createGain();
-    effectLevelNode.gain.value = 1.0; // effect level slider controls this
-    effectLevelNode.connect(masterGainNode);
+  // Create effect volume.
+  effectLevelNode = context.createGain();
+  effectLevelNode.gain.value = 1.0; // effect level slider controls this
+  effectLevelNode.connect(masterGainNode);
 
-    // Create convolver for effect
-    convolver = context.createConvolver();
-    convolver.connect(effectLevelNode);
+  // Create convolver for effect
+  convolver = context.createConvolver();
+  convolver.connect(effectLevelNode);
 
-    updateControls();
+  updateControls();
 }
 
 function initControls() {
-    // Initialize note buttons
-    ui.notes = new Notes();
-    ui.notes.onClick = (instrumentName, rhythm) => handleNoteClick(instrumentName, rhythm);
+  // Initialize note buttons
+  ui.notes = new Notes();
+  ui.notes.onClick = (instrumentName, rhythm) => handleNoteClick(instrumentName, rhythm);
 
-    ui.kitPicker = new KitPicker();
-    ui.kitPicker.addOptions(KITS.map(kit => kit.prettyName));
-    ui.kitPicker.onSelect = (i) => handleKitChange(i);
+  ui.kitPicker = new KitPicker();
+  ui.kitPicker.addOptions(KITS.map((kit) => kit.prettyName));
+  ui.kitPicker.onSelect = (i) => handleKitChange(i);
 
-    ui.effectPicker = new EffectPicker();
-    ui.effectPicker.addOptions(impulseResponses.map(e => e.name));
-    ui.effectPicker.onSelect = (i) => handleEffectChange(i);
+  ui.effectPicker = new EffectPicker();
+  ui.effectPicker.addOptions(impulseResponses.map((e) => e.name));
+  ui.effectPicker.onSelect = (i) => handleEffectChange(i);
 
-    ui.effectSlider = new EffectSlider();
-    ui.effectSlider.onchange = (value) => {
-        // Change the volume of the convolution effect.
-        theBeat.effectMix = value;
-        setEffectLevel(theBeat);
-    };
+  ui.effectSlider = new EffectSlider();
+  ui.effectSlider.onchange = (value) => {
+    // Change the volume of the convolution effect.
+    theBeat.effectMix = value;
+    setEffectLevel(theBeat);
+  };
 
-    ui.swingSlider = new SwingSlider();
-    ui.swingSlider.onchange = (value) => {
-        theBeat.swingFactor = value;
-    };
+  ui.swingSlider = new SwingSlider();
+  ui.swingSlider.onchange = (value) => {
+    theBeat.swingFactor = value;
+  };
 
-    ui.pitchSliders = new PitchSliders();
-    ui.pitchSliders.onPitchChange = (instrumentName, pitch) => setPitch(instrumentName, pitch);
+  ui.pitchSliders = new PitchSliders();
+  ui.pitchSliders.onPitchChange = (instrumentName, pitch) => setPitch(instrumentName, pitch);
 
-    // tool buttons
-    ui.playButton = new PlayButton();
-    ui.playButton.onclick = () => {
-        if (ui.playButton.state === "playing") {
-            handleStop();
-        } else if (ui.playButton.state === "stopped") {
-            handlePlay();
-        }
-    };
+  ui.playButton = new PlayButton();
+  ui.playButton.onclick = () => {
+    if (ui.playButton.state === 'playing') {
+      handleStop();
+    } else if (ui.playButton.state === 'stopped') {
+      handlePlay();
+    }
+  };
 
-    ui.modal.save = new SaveModal(() => JSON.stringify(theBeat));
-    ui.modal.load = new LoadModal();
-    ui.modal.load.onLoad = (data) => handleLoad(data);
+  ui.modal.save = new SaveModal(() => JSON.stringify(theBeat));
+  ui.modal.load = new LoadModal();
+  ui.modal.load.onLoad = (data) => handleLoad(data);
 
-    ui.resetButton = new ResetButton();
-    ui.resetButton.onclick = () => {
-        loadBeat(RESET_BEAT);
-    };
+  ui.resetButton = new ResetButton();
+  ui.resetButton.onclick = () => {
+    loadBeat(RESET_BEAT);
+  };
 
-    ui.demoButtons = new DemoButtons();
-    ui.demoButtons.onDemoClick = (demoIndex) => {
-        loadBeat(DEMO_BEATS[demoIndex]);
-        handlePlay();
-    };
+  ui.demoButtons = new DemoButtons();
+  ui.demoButtons.onDemoClick = (demoIndex) => {
+    loadBeat(DEMO_BEATS[demoIndex]);
+    handlePlay();
+  };
 
-    ui.tempoInput = new TempoInput({ min: MIN_TEMPO, max: MAX_TEMPO, step: 4 });
-    ui.tempoInput.onTempoChange = (tempo) => {
-        theBeat.tempo = tempo;
-    };
+  ui.tempoInput = new TempoInput({min: MIN_TEMPO, max: MAX_TEMPO, step: 4});
+  ui.tempoInput.onTempoChange = (tempo) => {
+    theBeat.tempo = tempo;
+  };
 
-    ui.playheads = new Playheads();
+  ui.playheads = new Playheads();
 }
 
 function setPitch(instrumentName, pitch) {
-    theBeat[`${instrumentName.toLowerCase()}PitchVal`] = pitch;
+  theBeat[`${instrumentName.toLowerCase()}PitchVal`] = pitch;
 }
 
 function getPitch(instrumentName) {
-    return theBeat[`${instrumentName.toLowerCase()}PitchVal`];
+  return theBeat[`${instrumentName.toLowerCase()}PitchVal`];
 }
 
 function getRhythm(instrumentName) {
-    const index = 1 + INSTRUMENTS.findIndex(i => i.name === instrumentName);
-    return theBeat[`rhythm${index}`];
+  const index = 1 + INSTRUMENTS.findIndex((i) => i.name === instrumentName);
+  return theBeat[`rhythm${index}`];
 }
 
 function advanceNote() {
-    // Advance time by a 16th note...
-    var secondsPerBeat = 60.0 / theBeat.tempo;
+  // Advance time by a 16th note...
+  const secondsPerBeat = 60.0 / theBeat.tempo;
 
-    rhythmIndex++;
-    if (rhythmIndex == LOOP_LENGTH) {
-        rhythmIndex = 0;
-    }
+  rhythmIndex++;
+  if (rhythmIndex == LOOP_LENGTH) {
+    rhythmIndex = 0;
+  }
 
-    // apply swing    
-    if (rhythmIndex % 2) {
-        noteTime += (0.25 + MAX_SWING * theBeat.swingFactor) * secondsPerBeat;
-    } else {
-        noteTime += (0.25 - MAX_SWING * theBeat.swingFactor) * secondsPerBeat;
-    }
+  // apply swing
+  if (rhythmIndex % 2) {
+    noteTime += (0.25 + MAX_SWING * theBeat.swingFactor) * secondsPerBeat;
+  } else {
+    noteTime += (0.25 - MAX_SWING * theBeat.swingFactor) * secondsPerBeat;
+  }
 }
 
 function playNote(instrument, rhythmIndex, noteTime) {
-    const note = getRhythm(instrument.name)[rhythmIndex];
+  const note = getRhythm(instrument.name)[rhythmIndex];
 
-    if (!note) {
-        return;
-    }
+  if (!note) {
+    return;
+  }
 
-    // Create the note
-    var voice = context.createBufferSource();
-    voice.buffer = getCurrentKit().buffer[instrument.name];
-    voice.playbackRate.value = computePlaybackRate(instrument.name);
+  // Create the note
+  const voice = context.createBufferSource();
+  voice.buffer = getCurrentKit().buffer[instrument.name];
+  voice.playbackRate.value = computePlaybackRate(instrument.name);
 
-    // Optionally, connect to a panner
-    var finalNode;
-    if (instrument.pan) {
-        var panner = context.createPanner();
-        // Pan according to sequence position.
-        panner.setPosition(0.5 * rhythmIndex - 4, 0, -1);
-        voice.connect(panner);
-        finalNode = panner;
-    } else {
-        finalNode = voice;
-    }
+  // Optionally, connect to a panner
+  let finalNode;
+  if (instrument.pan) {
+    const panner = context.createPanner();
+    // Pan according to sequence position.
+    panner.setPosition(0.5 * rhythmIndex - 4, 0, -1);
+    voice.connect(panner);
+    finalNode = panner;
+  } else {
+    finalNode = voice;
+  }
 
-    // Connect to dry mix
-    var dryGainNode = context.createGain();
-    dryGainNode.gain.value = VOLUMES[note] * instrument.mainGain * effectDryMix;
-    finalNode.connect(dryGainNode);
-    dryGainNode.connect(masterGainNode);
+  // Connect to dry mix
+  const dryGainNode = context.createGain();
+  dryGainNode.gain.value = VOLUMES[note] * instrument.mainGain * effectDryMix;
+  finalNode.connect(dryGainNode);
+  dryGainNode.connect(masterGainNode);
 
-    // Connect to wet mix
-    var wetGainNode = context.createGain();
-    wetGainNode.gain.value = instrument.sendGain;
-    finalNode.connect(wetGainNode);
-    wetGainNode.connect(convolver);
+  // Connect to wet mix
+  const wetGainNode = context.createGain();
+  wetGainNode.gain.value = instrument.sendGain;
+  finalNode.connect(wetGainNode);
+  wetGainNode.connect(convolver);
 
-    voice.start(noteTime);
+  voice.start(noteTime);
 }
 
 function schedule() {
-    var currentTime = context.currentTime;
+  let currentTime = context.currentTime;
 
-    // The sequence starts at startTime, so normalize currentTime so that it's 0 at the start of the sequence.
-    currentTime -= startTime;
+  // The sequence starts at startTime, so normalize currentTime so that it's 0 at the start of the sequence.
+  currentTime -= startTime;
 
-    while (noteTime < currentTime + 0.200) {
-        // Convert noteTime to context time.
-        const contextPlayTime = noteTime + startTime;
+  while (noteTime < currentTime + 0.200) {
+    // Convert noteTime to context time.
+    const contextPlayTime = noteTime + startTime;
 
-        for (const instrument of INSTRUMENTS) {
-            playNote(instrument, rhythmIndex, contextPlayTime);
-        }
-
-        // Attempt to synchronize drawing time with sound
-        if (noteTime != lastDrawTime) {
-            lastDrawTime = noteTime;
-            ui.playheads.drawPlayhead((rhythmIndex + 15) % 16);
-        }
-
-        advanceNote();
+    for (const instrument of INSTRUMENTS) {
+      playNote(instrument, rhythmIndex, contextPlayTime);
     }
 
-    timeoutId = setTimeout(schedule, 0);
+    // Attempt to synchronize drawing time with sound
+    if (noteTime != lastDrawTime) {
+      lastDrawTime = noteTime;
+      ui.playheads.drawPlayhead((rhythmIndex + 15) % 16);
+    }
+
+    advanceNote();
+  }
+
+  timeoutId = setTimeout(schedule, 0);
 }
 
 function computePlaybackRate(instrumentName) {
-    const pitch = getPitch(instrumentName);
-    return Math.pow(2.0, 2.0 * (pitch - 0.5));
+  const pitch = getPitch(instrumentName);
+  return Math.pow(2.0, 2.0 * (pitch - 0.5));
 }
 
 function handleNoteClick(instrumentName, rhythmIndex) {
-    const instrument = INSTRUMENTS.find(i => i.name === instrumentName);
-    const notes = getRhythm(instrumentName);
-    const note = (notes[rhythmIndex] + 1) % 3
-    notes[rhythmIndex] = note;
+  const instrument = INSTRUMENTS.find((i) => i.name === instrumentName);
+  const notes = getRhythm(instrumentName);
+  const note = (notes[rhythmIndex] + 1) % 3;
+  notes[rhythmIndex] = note;
 
-    ui.notes.setNote(instrument.name, rhythmIndex, notes[rhythmIndex]);
+  ui.notes.setNote(instrument.name, rhythmIndex, notes[rhythmIndex]);
 
-    playNote(instrument, rhythmIndex, 0);
+  playNote(instrument, rhythmIndex, 0);
 }
 
 function handleKitChange(index) {
-    theBeat.kitIndex = index;
+  theBeat.kitIndex = index;
 }
 
 function handleEffectChange(index) {
-    // Hack - if effect is turned all the way down - turn up effect slider.
-    // ... since they just explicitly chose an effect from the list.
-    if (theBeat.effectMix == 0)
-        theBeat.effectMix = 0.5;
+  // Hack - if effect is turned all the way down - turn up effect slider.
+  // ... since they just explicitly chose an effect from the list.
+  if (theBeat.effectMix == 0) {
+    theBeat.effectMix = 0.5;
+  }
 
-    setEffect(index);
+  setEffect(index);
 }
 
 async function setEffect(index) {
-    await impulseResponses[index].load();
+  await impulseResponses[index].load();
 
-    theBeat.effectIndex = index;
-    effectDryMix = IMPULSE_RESPONSE_DATA[index].dryMix;
-    effectWetMix = IMPULSE_RESPONSE_DATA[index].wetMix;
-    convolver.buffer = impulseResponses[index].buffer;
+  theBeat.effectIndex = index;
+  effectDryMix = IMPULSE_RESPONSE_DATA[index].dryMix;
+  effectWetMix = IMPULSE_RESPONSE_DATA[index].wetMix;
+  convolver.buffer = impulseResponses[index].buffer;
 
-    // Hack - if the effect is meant to be entirely wet (not unprocessed signal)
-    // then put the effect level all the way up.
-    if (effectDryMix == 0)
-        theBeat.effectMix = 1;
+  // Hack - if the effect is meant to be entirely wet (not unprocessed signal)
+  // then put the effect level all the way up.
+  if (effectDryMix == 0) {
+    theBeat.effectMix = 1;
+  }
 
-    setEffectLevel(theBeat);
-    updateControls();
+  setEffectLevel(theBeat);
+  updateControls();
 
-    ui.effectPicker.select(index);
+  ui.effectPicker.select(index);
 }
 
 function setEffectLevel() {
-    // Factor in both the preset's effect level and the blending level (effectWetMix) stored in the effect itself.
-    effectLevelNode.gain.value = theBeat.effectMix * effectWetMix;
+  // Factor in both the preset's effect level and the blending level (effectWetMix) stored in the effect itself.
+  effectLevelNode.gain.value = theBeat.effectMix * effectWetMix;
 }
 
 function handlePlay() {
-    noteTime = 0.0;
-    startTime = context.currentTime + 0.005;
-    schedule();
+  noteTime = 0.0;
+  startTime = context.currentTime + 0.005;
+  schedule();
 
-    ui.playButton.state = "playing";
+  ui.playButton.state = 'playing';
 }
 
 function handleStop() {
-    clearTimeout(timeoutId);
+  clearTimeout(timeoutId);
 
-    rhythmIndex = 0;
+  rhythmIndex = 0;
 
-    ui.playheads.off();
-    ui.playButton.state = "stopped";
+  ui.playheads.off();
+  ui.playButton.state = 'stopped';
 }
 
 function handleLoad(data) {
-    theBeat = JSON.parse(data);
+  theBeat = JSON.parse(data);
 
-    // Set effect
-    setEffect(theBeat.effectIndex);
+  // Set effect
+  setEffect(theBeat.effectIndex);
 
-    // Change the volume of the convolution effect.
-    setEffectLevel(theBeat);
+  // Change the volume of the convolution effect.
+  setEffectLevel(theBeat);
 
-    updateControls();
+  updateControls();
 }
 
 function loadBeat(beat) {
-    handleStop();
+  handleStop();
 
-    theBeat = clone(beat);
-    setEffect(theBeat.effectIndex);
+  theBeat = clone(beat);
+  setEffect(theBeat.effectIndex);
 
-    updateControls();
+  updateControls();
 
-    return true;
+  return true;
 }
 
 function updateControls() {
-    let notes;
+  let notes;
 
-    for (const instrument of INSTRUMENTS) {
-        const notes = getRhythm(instrument.name);
-        for (let i = 0; i < LOOP_LENGTH; ++i) {
-            ui.notes.setNote(instrument.name, i, notes[i]);
-        }
+  for (const instrument of INSTRUMENTS) {
+    const notes = getRhythm(instrument.name);
+    for (let i = 0; i < LOOP_LENGTH; ++i) {
+      ui.notes.setNote(instrument.name, i, notes[i]);
     }
+  }
 
-    ui.kitPicker.select(theBeat.kitIndex);
-    ui.effectPicker.select(theBeat.effectIndex);
-    ui.tempoInput.value = theBeat.tempo;
-    ui.effectSlider.value = theBeat.effectMix;
-    ui.swingSlider.value = theBeat.swingFactor;
+  ui.kitPicker.select(theBeat.kitIndex);
+  ui.effectPicker.select(theBeat.effectIndex);
+  ui.tempoInput.value = theBeat.tempo;
+  ui.effectSlider.value = theBeat.effectMix;
+  ui.swingSlider.value = theBeat.swingFactor;
 
-    for (const instrument of INSTRUMENTS) {
-        ui.pitchSliders.setPitch(instrument.name, getPitch(instrument.name));
-    }
+  for (const instrument of INSTRUMENTS) {
+    ui.pitchSliders.setPitch(instrument.name, getPitch(instrument.name));
+  }
 }

--- a/archive/demos/shiny-drum-machine.js
+++ b/archive/demos/shiny-drum-machine.js
@@ -480,13 +480,8 @@ function initControls() {
 }
 
 function initButtons() {        
-    var elButton;
-
-    for (i = 0; i < loopLength; ++i) {
-        for (j = 0; j < kNumInstruments; j++) {
-                elButton = document.getElementById(instruments[j] + '_' + i);
-                elButton.addEventListener("click", handleButtonMouseDown, true);
-        }
+    for(const elButton of document.querySelectorAll("[data-instrument][data-rhythm]")) {
+        elButton.addEventListener("click", handleButtonMouseDown, true);
     }
 }
 
@@ -676,29 +671,14 @@ function sliderSetPosition(slider, value) {
 }
 
 function handleButtonMouseDown(event) {
-    var notes = theBeat.rhythm1;
-    
-    var instrumentIndex;
-    var rhythmIndex;
+    const rhythmIndex = new Number(event.target.dataset.rhythm);
+    const instrument = event.target.dataset.instrument;
+    const instrumentIndex = instruments.indexOf(instrument);
+    const notes = theBeat[`rhythm${instrumentIndex + 1}`];    
+    const note = (notes[rhythmIndex] + 1) % 3
+    notes[rhythmIndex] = note;
 
-    var elId = event.target.id;
-    rhythmIndex = elId.substr(elId.indexOf('_') + 1, 2);
-    instrumentIndex = instruments.indexOf(elId.substr(0, elId.indexOf('_')));
-        
-    switch (instrumentIndex) {
-        case 0: notes = theBeat.rhythm1; break;
-        case 1: notes = theBeat.rhythm2; break;
-        case 2: notes = theBeat.rhythm3; break;
-        case 3: notes = theBeat.rhythm4; break;
-        case 4: notes = theBeat.rhythm5; break;
-        case 5: notes = theBeat.rhythm6; break;
-    }
-
-    notes[rhythmIndex] = (notes[rhythmIndex] + 1) % 3;
-
-    drawNote(notes[rhythmIndex], rhythmIndex, instrumentIndex);
-
-    var note = notes[rhythmIndex];
+    drawNote(notes[rhythmIndex], rhythmIndex, instrument);
     
     if (note) {
         switch(instrumentIndex) {
@@ -925,7 +905,7 @@ function updateControls() {
                 case 5: notes = theBeat.rhythm6; break;
             }
 
-            drawNote(notes[i], i, j);
+            drawNote(notes[i], i, instruments[j]);
         }
     }
 
@@ -943,13 +923,9 @@ function updateControls() {
 }
 
 
-function drawNote(draw, xindex, yindex) {    
-    var elButton = document.getElementById(instruments[yindex] + '_' + xindex);
-    switch (draw) {
-        case 0: elButton.src = 'images/button_off.png'; break;
-        case 1: elButton.src = 'images/button_half.png'; break;
-        case 2: elButton.src = 'images/button_on.png'; break;
-    }
+function drawNote(note, rhythmIndex, instrument) {    
+    const elButton = document.querySelector(`[data-rhythm="${rhythmIndex}"][data-instrument="${instrument}"]`);
+    elButton.dataset.note = note;
 }
 
 function drawPlayhead(xindex) {

--- a/archive/demos/shiny-drum-machine.js
+++ b/archive/demos/shiny-drum-machine.js
@@ -75,11 +75,6 @@ var noteTime = 0.0;
 
 var instruments = ['Kick', 'Snare', 'HiHat', 'Tom1', 'Tom2', 'Tom3'];
 
-const pitch = {};
-for(const instrument of instruments) {
-    pitch[instrument] = 0;
-}
-
 var volumes = [0, 0.3, 1];
 
 var kitCount = 0;
@@ -598,31 +593,31 @@ function schedule() {
         
         // Kick
         if (theBeat.rhythm1[rhythmIndex]) {
-            playNote(currentKit.kickBuffer, false, 0,0,-2, 0.5, volumes[theBeat.rhythm1[rhythmIndex]] * 1.0, pitch['Kick'], contextPlayTime);
+            playNote(currentKit.kickBuffer, false, 0,0,-2, 0.5, volumes[theBeat.rhythm1[rhythmIndex]] * 1.0, computePlaybackRate('Kick'), contextPlayTime);
         }
 
         // Snare
         if (theBeat.rhythm2[rhythmIndex]) {
-            playNote(currentKit.snareBuffer, false, 0,0,-2, 1, volumes[theBeat.rhythm2[rhythmIndex]] * 0.6, pitch['Snare'], contextPlayTime);
+            playNote(currentKit.snareBuffer, false, 0,0,-2, 1, volumes[theBeat.rhythm2[rhythmIndex]] * 0.6, computePlaybackRate('Snare'), contextPlayTime);
         }
 
         // Hihat
         if (theBeat.rhythm3[rhythmIndex]) {
             // Pan the hihat according to sequence position.
-            playNote(currentKit.hihatBuffer, true, 0.5*rhythmIndex - 4, 0, -1.0, 1, volumes[theBeat.rhythm3[rhythmIndex]] * 0.7, pitch['HiHat'], contextPlayTime);
+            playNote(currentKit.hihatBuffer, true, 0.5*rhythmIndex - 4, 0, -1.0, 1, volumes[theBeat.rhythm3[rhythmIndex]] * 0.7, computePlaybackRate('HiHat'), contextPlayTime);
         }
 
         // Toms    
         if (theBeat.rhythm4[rhythmIndex]) {
-            playNote(currentKit.tom1, false, 0,0,-2, 1, volumes[theBeat.rhythm4[rhythmIndex]] * 0.6, pitch['Tom1'], contextPlayTime);
+            playNote(currentKit.tom1, false, 0,0,-2, 1, volumes[theBeat.rhythm4[rhythmIndex]] * 0.6, computePlaybackRate('Tom1'), contextPlayTime);
         }
 
         if (theBeat.rhythm5[rhythmIndex]) {
-            playNote(currentKit.tom2, false, 0,0,-2, 1, volumes[theBeat.rhythm5[rhythmIndex]] * 0.6, pitch['Tom2'], contextPlayTime);
+            playNote(currentKit.tom2, false, 0,0,-2, 1, volumes[theBeat.rhythm5[rhythmIndex]] * 0.6, computePlaybackRate('Tom2'), contextPlayTime);
         }
 
         if (theBeat.rhythm6[rhythmIndex]) {
-            playNote(currentKit.tom3, false, 0,0,-2, 1, volumes[theBeat.rhythm6[rhythmIndex]] * 0.6, pitch['Tom3'], contextPlayTime);
+            playNote(currentKit.tom3, false, 0,0,-2, 1, volumes[theBeat.rhythm6[rhythmIndex]] * 0.6, computePlaybackRate('Tom3'), contextPlayTime);
         }
 
         
@@ -650,7 +645,11 @@ function tempoDecrease() {
 
 function setPitch(instrument, value) {
     theBeat[`${instrument.toLowerCase()}PitchVal`] = value;
-    pitch[instrument] =  Math.pow(2.0, 2.0 * (value - 0.5));
+}
+
+function computePlaybackRate(instrument) {
+    const pitch = theBeat[`${instrument.toLowerCase()}PitchVal`];
+    return Math.pow(2.0, 2.0 * (pitch - 0.5));
 }
 
 function handleButtonMouseDown(event) {
@@ -666,28 +665,28 @@ function handleButtonMouseDown(event) {
     if (note) {
         switch(instrumentIndex) {
         case 0:  // Kick
-          playNote(currentKit.kickBuffer, false, 0,0,-2, 0.5 * theBeat.effectMix, volumes[note] * 1.0, pitch['Kick'], 0);
+          playNote(currentKit.kickBuffer, false, 0,0,-2, 0.5 * theBeat.effectMix, volumes[note] * 1.0, computePlaybackRate('Kick'), 0);
           break;
 
         case 1:  // Snare
-          playNote(currentKit.snareBuffer, false, 0,0,-2, theBeat.effectMix, volumes[note] * 0.6, pitch['Snare'], 0);
+          playNote(currentKit.snareBuffer, false, 0,0,-2, theBeat.effectMix, volumes[note] * 0.6, computePlaybackRate('Snare'), 0);
           break;
 
         case 2:  // Hihat
           // Pan the hihat according to sequence position.
-          playNote(currentKit.hihatBuffer, true, 0.5*rhythmIndex - 4, 0, -1.0, theBeat.effectMix, volumes[note] * 0.7, pitch['HiHat'], 0);
+          playNote(currentKit.hihatBuffer, true, 0.5*rhythmIndex - 4, 0, -1.0, theBeat.effectMix, volumes[note] * 0.7, computePlaybackRate('HiHat'), 0);
           break;
 
         case 3:  // Tom 1   
-          playNote(currentKit.tom1, false, 0,0,-2, theBeat.effectMix, volumes[note] * 0.6, pitch['Tom1'], 0);
+          playNote(currentKit.tom1, false, 0,0,-2, theBeat.effectMix, volumes[note] * 0.6, computePlaybackRate('Tom1'), 0);
           break;
 
         case 4:  // Tom 2   
-          playNote(currentKit.tom2, false, 0,0,-2, theBeat.effectMix, volumes[note] * 0.6, pitch['Tom2'], 0);
+          playNote(currentKit.tom2, false, 0,0,-2, theBeat.effectMix, volumes[note] * 0.6, computePlaybackRate('Tom2'), 0);
           break;
 
         case 5:  // Tom 3   
-          playNote(currentKit.tom3, false, 0,0,-2, theBeat.effectMix, volumes[note] * 0.6, pitch['Tom3'], 0);
+          playNote(currentKit.tom3, false, 0,0,-2, theBeat.effectMix, volumes[note] * 0.6, computePlaybackRate('Tom3'), 0);
           break;
         }
     }
@@ -809,14 +808,6 @@ function handleLoadOk(event) {
     // Change the volume of the convolution effect.
     setEffectLevel(theBeat);
 
-    // Apply values from sliders
-    setPitch('Kick', theBeat.kickPitchVal);
-    setPitch('Snare', theBeat.snarePitchVal);
-    setPitch('HiHat', theBeat.hihatPitchVal);
-    setPitch('Tom1', theBeat.tom1PitchVal);
-    setPitch('Tom2', theBeat.tom2PitchVal);
-    setPitch('Tom3', theBeat.tom3PitchVal);
-
     // Clear out the text area post-processing
     elTextarea.value = '';
 
@@ -857,13 +848,6 @@ function loadBeat(beat) {
     theBeat = cloneBeat(beat);
     currentKit = kits[theBeat.kitIndex];
     setEffect(theBeat.effectIndex);
-
-    setPitch('Kick', theBeat.kickPitchVal);
-    setPitch('Snare', theBeat.snarePitchVal);
-    setPitch('HiHat', theBeat.hihatPitchVal);
-    setPitch('Tom1', theBeat.tom1PitchVal);
-    setPitch('Tom2', theBeat.tom2PitchVal);
-    setPitch('Tom3', theBeat.tom3PitchVal);
 
     updateControls();
 

--- a/archive/demos/style/drummachine.css
+++ b/archive/demos/style/drummachine.css
@@ -117,12 +117,71 @@ body {
 	height: 38px;
 }
 
-.note[data-note="1"] {
+.note[data-state="1"] {
 	background-image: url(../images/button_half.png);
 }
 
-.note[data-note="2"] {
+.note[data-state="2"] {
 	background-image: url(../images/button_on.png);
+}
+
+.play {
+	background-image: url(../images/btn_play_loading.gif);
+	width: 80px;
+	height: 33px;
+}
+
+.play[data-state="stopped"] {
+	background-image: url(../images/btn_play.png);
+}
+
+.play[data-state="playing"] {
+	background-image: url(../images/btn_stop.png);
+}
+
+.demo {
+	width: 44px;
+	height: 33px;
+}
+
+.demo[data-demo="0"] {
+	background-image: url(../images/btn_demo1_loading.gif);
+}
+
+.demo[data-demo="1"] {
+	background-image: url(../images/btn_demo2_loading.gif);
+}
+
+.demo[data-demo="2"] {
+	background-image: url(../images/btn_demo3_loading.gif);
+}
+
+.demo[data-demo="3"] {
+	background-image: url(../images/btn_demo4_loading.gif);
+}
+
+.demo[data-demo="4"] {
+	background-image: url(../images/btn_demo5_loading.gif);
+}
+
+.demo[data-demo="0"][data-state="loaded"] {
+	background-image: url(../images/btn_demo1.png);
+}
+
+.demo[data-demo="1"][data-state="loaded"] {
+	background-image: url(../images/btn_demo2.png);
+}
+
+.demo[data-demo="2"][data-state="loaded"] {
+	background-image: url(../images/btn_demo3.png);
+}
+
+.demo[data-demo="3"][data-state="loaded"] {
+	background-image: url(../images/btn_demo4.png);
+}
+
+.demo[data-demo="4"][data-state="loaded"] {
+	background-image: url(../images/btn_demo5.png);
 }
 
 select {

--- a/archive/demos/style/drummachine.css
+++ b/archive/demos/style/drummachine.css
@@ -111,6 +111,20 @@ body {
 	border: 0;
 }
 
+.note {
+	background: url(../images/button_off.png) no-repeat center;
+	width: 38px;
+	height: 38px;
+}
+
+.note[data-note="1"] {
+	background-image: url(../images/button_half.png);
+}
+
+.note[data-note="2"] {
+	background-image: url(../images/button_on.png);
+}
+
 select {
 	appearance: none;
 	cursor: pointer;


### PR DESCRIPTION
See #226.

Sorry for the huge PR. Now that the code is a bit cleaned up and modularized, I hope that follow up PRs can be shorter.

 * Use data attributes to remove hardcoded IDs and URLs from note buttons.
 * Introduce Slider ViewModel to simplify two-way binding.
 * Compute playbackRate on the fly to reduce data duplication.
 * Introduce button data-attrs to replace hardcoded URLs and IDs.
 * Refactor Kit to use ES6-class, fetch, and Promises.
 * Refactor to ES6 module, extract static data to data.js.
 * Refactor and extract UI bindings to ui.js.
 * Refactor hardcoded instrument mappings.

