### PR TITLE
Refactor drum machine audio playback and scheduling

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,8 +8,14 @@
         "google"
     ],
     "ignorePatterns": [
-        "archive/", 
-        "audio-worklet/"
+        "/archive/demos/**", 
+        "!/archive/demos/shiny-drum-machine*", 
+        "/archive/stress-box", 
+        "/assets",
+        "/audio-worklet",
+        "/gulpfile.js",
+        "/home",
+        "/src"
     ],
     "parserOptions": {
         "ecmaVersion": 12,

--- a/archive/demos/shiny-drum-machine-audio.js
+++ b/archive/demos/shiny-drum-machine-audio.js
@@ -308,6 +308,7 @@ class Player {
     this.noteTime = 0.0;
     this.startTime = context.currentTime + 0.005;
     this.rhythmIndex = 0;
+    this.onNextBeat(this.rhythmIndex);
     this.schedule();
   }
 

--- a/archive/demos/shiny-drum-machine-audio.js
+++ b/archive/demos/shiny-drum-machine-audio.js
@@ -1,0 +1,320 @@
+/* eslint require-jsdoc: "off" */
+
+import {INSTRUMENTS, freeze, clone} from './shiny-drum-machine-data.js';
+
+const AudioContext = window.AudioContext ?? window.webkitAudioContext;
+
+const context = new AudioContext();
+
+const MAX_SWING = 0.08;
+const LOOP_LENGTH = 16;
+const VOLUMES = freeze([0, 0.3, 1]);
+
+
+async function fetchAudio(url) {
+  const response = await fetch(new Request(url));
+  const responseBuffer = await response.arrayBuffer();
+
+  // TODO(#226): Migrate to Promise-syntax once Safari supports it.
+  return new Promise((resolve, reject) => {
+    context.decodeAudioData(responseBuffer, resolve, reject);
+  });
+}
+
+class Kit {
+  constructor(id, prettyName, index) {
+    this.id = id;
+    this.prettyName = prettyName;
+    this.index = index;
+    this.buffer = {};
+  }
+
+  getSampleUrl(instrumentName) {
+    return `sounds/drum-samples/${this.id}/${instrumentName.toLowerCase()}.wav`;
+  }
+
+  load() {
+    const instrumentPromises = INSTRUMENTS.map(
+        (instrument) => this.loadSample(instrument.name));
+    const promise = Promise.all(instrumentPromises).then(() => null);
+    // Return original Promise on subsequent load calls to avoid duplicate
+    // loads.
+    this.load = () => promise;
+    return promise;
+  }
+
+  async loadSample(instrumentName) {
+    this.buffer[instrumentName] = await fetchAudio(
+        this.getSampleUrl(instrumentName));
+  }
+}
+
+
+class Effect {
+  constructor(data, index) {
+    this.name = data.name;
+    this.url = data.url;
+    this.dryMix = data.dryMix;
+    this.wetMix = data.wetMix;
+    this.index = index;
+    this.buffer = undefined;
+  }
+
+  async load() {
+    // Return if buffer has been loaded already or there is nothing to load
+    // ("No effect" instance).
+    if (!this.url || this.buffer) {
+      return;
+    }
+
+    this.buffer = await fetchAudio(this.url);
+  }
+}
+
+
+class Beat {
+  constructor(data, kits, effects) {
+    this.kits = kits;
+    this.effects = effects;
+    this.loadObject(data);
+  }
+
+  loadObject(data) {
+    this._data = Object.seal(clone(data));
+    this._kit = this.kits[data.kitIndex];
+    this._effect = this.effects[data.effectIndex];
+  }
+
+  toObject() {
+    return clone(this._data);
+  }
+
+  set kit(kit) {
+    this._kit = kit;
+    this._data.kitIndex = kit.index;
+  }
+
+  get kit() {
+    return this._kit;
+  }
+
+  set effect(effect) {
+    this._effect = effect;
+    this._data.effectIndex = effect.index;
+
+    // Hack - if effect is turned all the way down - turn up effect slider.
+    // ... since they just explicitly chose an effect from the list.
+    if (this._data.effectMix == 0) {
+      this._data.effectMix = 0.5;
+    }
+
+    // Hack - if the effect is meant to be entirely wet (not unprocessed signal)
+    // then put the effect level all the way up.
+    if (effect.dryMix == 0) {
+      this._data.effectMix = 1;
+    }
+  }
+
+  get effect() {
+    return this._effect;
+  }
+
+  set effectMix(effectMix) {
+    this._data.effectMix = effectMix;
+  }
+
+  get effectMix() {
+    return this._data.effectMix;
+  }
+
+  setPitch(instrumentName, pitch) {
+    this._data[`${instrumentName.toLowerCase()}PitchVal`] = pitch;
+  }
+
+  getPitch(instrumentName) {
+    return this._data[`${instrumentName.toLowerCase()}PitchVal`];
+  }
+
+  getPlaybackRate(instrumentName) {
+    const pitch = this.getPitch(instrumentName);
+    return Math.pow(2.0, 2.0 * (pitch - 0.5));
+  }
+
+  set swingFactor(swingFactor) {
+    this._data.swingFactor = swingFactor;
+  }
+
+  get swingFactor() {
+    return this._data.swingFactor;
+  }
+
+  set tempo(tempo) {
+    this._data.tempo = tempo;
+  }
+
+  get tempo() {
+    return this._data.tempo;
+  }
+
+  getRhythm(instrumentName) {
+    const index = 1 + INSTRUMENTS.findIndex((i) => i.name === instrumentName);
+    return this._data[`rhythm${index}`];
+  }
+
+  toggleNote(instrumentName, rhythmIndex) {
+    const notes = this.getRhythm(instrumentName);
+    const note = (notes[rhythmIndex] + 1) % 3;
+    notes[rhythmIndex] = note;
+  }
+
+  getNote(instrumentName, rhythmIndex) {
+    const notes = this.getRhythm(instrumentName);
+    return notes[rhythmIndex];
+  }
+}
+
+class Player {
+  constructor(beat, onNextBeat) {
+    this.beat = beat;
+    this.onNextBeat = onNextBeat;
+
+    let finalMixNode;
+    if (context.createDynamicsCompressor) {
+      // Create a dynamics compressor to sweeten the overall mix.
+      const compressor = context.createDynamicsCompressor();
+      compressor.connect(context.destination);
+      finalMixNode = compressor;
+    } else {
+      // No compressor available in this implementation.
+      finalMixNode = context.destination;
+    }
+
+    // Create master volume.
+    this.masterGainNode = context.createGain();
+    // Reduce overall volume to avoid clipping.
+    this.masterGainNode.gain.value = 0.7;
+    this.masterGainNode.connect(finalMixNode);
+
+    // Create effect volume.
+    this.effectLevelNode = context.createGain();
+    this.effectLevelNode.gain.value = 1.0; // effect level slider controls this
+    this.effectLevelNode.connect(this.masterGainNode);
+
+    // Create convolver for effect
+    this.convolver = context.createConvolver();
+    this.convolver.connect(this.effectLevelNode);
+  }
+
+  advanceNote() {
+    // Advance time by a 16th note...
+    const secondsPerBeat = 60.0 / this.beat.tempo;
+
+    this.rhythmIndex = (this.rhythmIndex + 1) % LOOP_LENGTH;
+
+    let increment = 0.25;
+    const swing = MAX_SWING * this.beat.swingFactor;
+
+    // apply swing
+    if (this.rhythmIndex % 2) {
+      increment += swing;
+    } else {
+      increment -= swing;
+    }
+
+    this.noteTime += increment * secondsPerBeat;
+  }
+
+  playNote(instrument, rhythmIndex) {
+    this.playNoteAtTime(instrument, rhythmIndex, 0);
+  }
+
+  playNoteAtTime(instrument, rhythmIndex, noteTime) {
+    const note = this.beat.getNote(instrument.name, rhythmIndex);
+
+    if (!note) {
+      return;
+    }
+
+    // Create the note
+    const voice = context.createBufferSource();
+    voice.buffer = this.beat.kit.buffer[instrument.name];
+    voice.playbackRate.value = this.beat.getPlaybackRate(instrument.name);
+
+    // Optionally, connect to a panner
+    let finalNode;
+    if (instrument.pan) {
+      const panner = context.createPanner();
+      // Pan according to sequence position.
+      panner.setPosition(0.5 * rhythmIndex - 4, 0, -1);
+      voice.connect(panner);
+      finalNode = panner;
+    } else {
+      finalNode = voice;
+    }
+
+    // Connect to dry mix
+    const dryGainNode = context.createGain();
+    dryGainNode.gain.value =
+        VOLUMES[note] * instrument.mainGain * this.beat.effect.dryMix;
+    finalNode.connect(dryGainNode);
+    dryGainNode.connect(this.masterGainNode);
+
+    // Connect to wet mix
+    const wetGainNode = context.createGain();
+    wetGainNode.gain.value = instrument.sendGain;
+    finalNode.connect(wetGainNode);
+    wetGainNode.connect(this.convolver);
+
+    voice.start(noteTime);
+  }
+
+  schedule() {
+    let currentTime = context.currentTime;
+
+    // The sequence starts at startTime, so normalize currentTime so that it's 0
+    // at the start of the sequence.
+    currentTime -= this.startTime;
+
+    while (this.noteTime < currentTime + 0.200) {
+      // Convert this.noteTime to context time.
+      const contextPlayTime = this.noteTime + this.startTime;
+
+      for (const instrument of INSTRUMENTS) {
+        this.playNoteAtTime(instrument, this.rhythmIndex, contextPlayTime);
+      }
+
+      // Attempt to synchronize drawing time with sound
+      if (this.noteTime != this.lastDrawTime) {
+        this.lastDrawTime = this.noteTime;
+        this.onNextBeat(this.rhythmIndex);
+      }
+
+      this.advanceNote();
+    }
+
+    this.timeoutId = setTimeout(() => this.schedule(), 0);
+  }
+
+  updateEffect() {
+    this.convolver.buffer = this.beat.effect.buffer;
+
+    // Factor in both the preset's effect level and the blending level
+    // (effectWetMix) stored in the effect itself.
+    this.effectLevelNode.gain.value =
+        this.beat.effectMix * this.beat.effect.wetMix;
+  }
+
+  play() {
+    this.noteTime = 0.0;
+    this.startTime = context.currentTime + 0.005;
+    this.rhythmIndex = 0;
+    this.schedule();
+  }
+
+  stop() {
+    clearTimeout(this.timeoutId);
+    this.rhythmIndex = 0;
+  }
+}
+
+export {Beat, Player, Effect, Kit, LOOP_LENGTH};

--- a/archive/demos/shiny-drum-machine-ui.js
+++ b/archive/demos/shiny-drum-machine-ui.js
@@ -92,10 +92,10 @@ class Playheads {
 
   drawPlayhead(index) {
     // TODO: Refactor, replace with data attributes.
-    this.current = index;
-    const lastIndex = (index + 15) % 16;
+    this.current = (index + 15) % 16;
+    const lastIndex = (this.current + 15) % 16;
 
-    const elNew = document.getElementById('LED_' + index);
+    const elNew = document.getElementById('LED_' + this.current);
     const elOld = document.getElementById('LED_' + lastIndex);
 
     elNew.src = 'images/LED_on.png';

--- a/archive/demos/shiny-drum-machine-ui.js
+++ b/archive/demos/shiny-drum-machine-ui.js
@@ -1,3 +1,5 @@
+/* eslint require-jsdoc: "off" */
+
 class Slider {
   constructor(element, opts = {}) {
     this.element = element;
@@ -16,7 +18,7 @@ class Slider {
   }
 
   get value() {
-    return new Number(this.element.value) / 100;
+    return Number(this.element.value) / 100;
   }
 
   set value(value) {
@@ -40,8 +42,10 @@ class PitchSliders {
   constructor(container=document) {
     this.sliders = {};
     this.onPitchChange = (instrument, pitch) => {};
-    for (const el of container.querySelectorAll('[data-instrument][data-pitch]')) {
-      this.sliders[el.dataset.instrument] = new Slider(el, {doubleClickValue: 0.5});
+    const selector = '[data-instrument][data-pitch]';
+    for (const el of container.querySelectorAll(selector)) {
+      this.sliders[el.dataset.instrument] = new Slider(el,
+          {doubleClickValue: 0.5});
       this.sliders[el.dataset.instrument].onchange = (value) => {
         this.onPitchChange(el.dataset.instrument, value);
       };
@@ -110,11 +114,11 @@ class DemoButtons {
     this.onDemoClick = onDemoClick;
 
     const onButtonClick = (event) => {
-      this.onDemoClick(new Number(event.target.dataset.demo));
+      this.onDemoClick(Number(event.target.dataset.demo));
     };
 
     for (const element of container.querySelectorAll(`[data-demo]`)) {
-      const demoIndex = new Number(element.dataset.demo);
+      const demoIndex = Number(element.dataset.demo);
       this.buttons[demoIndex] = new Button(element, onButtonClick);
     }
   }
@@ -128,7 +132,8 @@ class Picker {
   constructor(element) {
     this.onSelect = (index) => {};
     this.element = element;
-    this.element.addEventListener('change', () => this.onSelect(this.element.selectedIndex));
+    this.element.addEventListener('change',
+        () => this.onSelect(this.element.selectedIndex));
   }
 
   addOptions(names) {
@@ -179,7 +184,7 @@ class TempoInput {
   }
 
   get value() {
-    return new Number(this.labelElement.innerText);
+    return Number(this.labelElement.innerText);
   }
 }
 
@@ -188,16 +193,18 @@ class Notes {
     this.onClick = (instrument, rhythm) => {};
 
     this.buttons = {};
-    for (const el of document.querySelectorAll(`[data-instrument][data-rhythm]`)) {
+    const selector = '[data-instrument][data-rhythm]';
+    for (const el of document.querySelectorAll(selector)) {
       const instrument = el.dataset.instrument;
-      const rhythm = new Number(el.dataset.rhythm);
+      const rhythm = Number(el.dataset.rhythm);
 
       if (!this.buttons[instrument]) {
         this.buttons[instrument] = {};
       }
 
       this.buttons[instrument][rhythm] = new Button(el);
-      this.buttons[instrument][rhythm].onclick = () => this.onClick(instrument, rhythm);
+      this.buttons[instrument][rhythm].onclick = () => this.onClick(
+          instrument, rhythm);
     }
   }
 

--- a/archive/demos/shiny-drum-machine-ui.js
+++ b/archive/demos/shiny-drum-machine-ui.js
@@ -88,23 +88,23 @@ class ResetButton extends Button {
 class Playheads {
   constructor() {
     this.current = 0;
+    this.leds = {};
+
+    const selector = '[data-led][data-rhythm]';
+    for (const el of document.querySelectorAll(selector)) {
+      const i = Number(el.dataset.rhythm);
+      this.leds[i] = el;
+    }
   }
 
   drawPlayhead(index) {
-    // TODO: Refactor, replace with data attributes.
-    this.current = (index + 15) % 16;
-    const lastIndex = (this.current + 15) % 16;
-
-    const elNew = document.getElementById('LED_' + this.current);
-    const elOld = document.getElementById('LED_' + lastIndex);
-
-    elNew.src = 'images/LED_on.png';
-    elOld.src = 'images/LED_off.png';
+    this.off();
+    this.current = index;
+    this.leds[this.current].dataset.led = 'on';
   }
 
   off() {
-    const el = document.getElementById(`LED_${this.current}`);
-    el.src = 'images/LED_off.png';
+    this.leds[this.current].dataset.led = 'off';
   }
 }
 

--- a/archive/demos/shiny-drum-machine.html
+++ b/archive/demos/shiny-drum-machine.html
@@ -166,22 +166,22 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         </div>
         <div class='buttons_row' id='LED_row'>
             <span class='label'></span>
-            <img id='LED_0' src='images/LED_off.png'>
-            <img id='LED_1' src='images/LED_off.png'>
-            <img id='LED_2' src='images/LED_off.png'>
-            <img id='LED_3' src='images/LED_off.png'>
-            <img id='LED_4' src='images/LED_off.png'>
-            <img id='LED_5' src='images/LED_off.png'>
-            <img id='LED_6' src='images/LED_off.png'>
-            <img id='LED_7' src='images/LED_off.png'>
-            <img id='LED_8' src='images/LED_off.png'>
-            <img id='LED_9' src='images/LED_off.png'>
-            <img id='LED_10' src='images/LED_off.png'>
-            <img id='LED_11' src='images/LED_off.png'>
-            <img id='LED_12' src='images/LED_off.png'>
-            <img id='LED_13' src='images/LED_off.png'>
-            <img id='LED_14' src='images/LED_off.png'>
-            <img id='LED_15' src='images/LED_off.png'>
+            <div class="led" data-led='off' data-rhythm='0'></div>
+            <div class="led" data-led='off' data-rhythm='1'></div>
+            <div class="led" data-led='off' data-rhythm='2'></div>
+            <div class="led" data-led='off' data-rhythm='3'></div>
+            <div class="led" data-led='off' data-rhythm='4'></div>
+            <div class="led" data-led='off' data-rhythm='5'></div>
+            <div class="led" data-led='off' data-rhythm='6'></div>
+            <div class="led" data-led='off' data-rhythm='7'></div>
+            <div class="led" data-led='off' data-rhythm='8'></div>
+            <div class="led" data-led='off' data-rhythm='9'></div>
+            <div class="led" data-led='off' data-rhythm='10'></div>
+            <div class="led" data-led='off' data-rhythm='11'></div>
+            <div class="led" data-led='off' data-rhythm='12'></div>
+            <div class="led" data-led='off' data-rhythm='13'></div>
+            <div class="led" data-led='off' data-rhythm='14'></div>
+            <div class="led" data-led='off' data-rhythm='15'></div>
         </div>
     </section>
     <section class='container active' id='params'>

--- a/archive/demos/shiny-drum-machine.js
+++ b/archive/demos/shiny-drum-machine.js
@@ -1,7 +1,7 @@
 /* eslint require-jsdoc: "off" */
 
-import {RESET_BEAT, DEMO_BEATS, INSTRUMENTS, KIT_DATA, IMPULSE_RESPONSE_DATA
-} from './shiny-drum-machine-data.js';
+import {RESET_BEAT, DEMO_BEATS, INSTRUMENTS, KIT_DATA,
+  IMPULSE_RESPONSE_DATA} from './shiny-drum-machine-data.js';
 
 import {DemoButtons, EffectPicker, KitPicker, EffectSlider, SwingSlider,
   PitchSliders, TempoInput, Playheads, Notes, SaveModal, LoadModal,

--- a/archive/demos/shiny-drum-machine.js
+++ b/archive/demos/shiny-drum-machine.js
@@ -1,50 +1,26 @@
 /* eslint require-jsdoc: "off" */
 
-import {RESET_BEAT, DEMO_BEATS, INSTRUMENTS, KIT_DATA, IMPULSE_RESPONSE_DATA,
-  freeze, clone} from './shiny-drum-machine-data.js';
+import {RESET_BEAT, DEMO_BEATS, INSTRUMENTS, KIT_DATA, IMPULSE_RESPONSE_DATA
+} from './shiny-drum-machine-data.js';
 
 import {DemoButtons, EffectPicker, KitPicker, EffectSlider, SwingSlider,
   PitchSliders, TempoInput, Playheads, Notes, SaveModal, LoadModal,
   ResetButton, PlayButton} from './shiny-drum-machine-ui.js';
 
+import {Beat, Player, Kit, Effect, LOOP_LENGTH} from './shiny-drum-machine-audio.js';
+
 
 // Events
 // init() once the page has finished loading.
-
-// Temporary patch until all browsers support unprefixed context.
-window.AudioContext = window.AudioContext || window.webkitAudioContext;
-
 window.onload = init;
 
-let context;
-let convolver;
-let compressor;
-let masterGainNode;
-let effectLevelNode;
-
-// Each effect impulse response has a specific overall desired dry and wet
-// volume. For example in the telephone filter, it's necessary to make the dry
-// volume 0 to correctly hear the effect.
-let effectDryMix = 1.0;
-let effectWetMix = 1.0;
-
-let timeoutId;
-let startTime;
-let lastDrawTime = -1;
-let rhythmIndex = 0;
-let noteTime = 0.0;
-
-const MAX_SWING = 0.08;
-const LOOP_LENGTH = 16;
 const MIN_TEMPO = 50;
 const MAX_TEMPO = 180;
-const VOLUMES = freeze([0, 0.3, 1]);
 
-// theBeat is the object representing the current beat/groove
-// ... it is saved/loaded via JSON
-let theBeat = clone(RESET_BEAT);
-let KITS;
-let impulseResponses;
+let theBeat;
+let player;
+const KITS = [];
+const EFFECTS = [];
 
 const ui = Object.seal({
   effectPicker: null,
@@ -64,67 +40,21 @@ const ui = Object.seal({
   },
 });
 
-async function fetchAudio(url) {
-  const response = await fetch(new Request(url));
-  const responseBuffer = await response.arrayBuffer();
-
-  // TODO(#226): Migrate to Promise-syntax once Safari supports it.
-  return new Promise((resolve, reject) => {
-    context.decodeAudioData(responseBuffer, resolve, reject);
-  });
-}
-
-class Kit {
-  constructor(id, prettyName) {
-    this.id = id;
-    this.prettyName = prettyName;
-    this.buffer = {};
+function loadAssets() {
+  // Any assets which have previously started loading will be skipped over.
+  for (const kit of KITS) {
+    kit.load();
   }
 
-  getSampleUrl(instrumentName) {
-    return `sounds/drum-samples/${this.id}/${instrumentName.toLowerCase()}.wav`;
-  }
-
-  load() {
-    const instrumentPromises = INSTRUMENTS.map(
-        (instrument) => this.loadSample(instrument.name));
-    const promise = Promise.all(instrumentPromises).then(() => null);
-    // Return original Promise on subsequent load calls to avoid duplicate
-    // loads.
-    this.load = () => promise;
-    return promise;
-  }
-
-  async loadSample(instrumentName) {
-    this.buffer[instrumentName] = await fetchAudio(
-        this.getSampleUrl(instrumentName));
-  }
-}
-
-
-class ImpulseResponse {
-  constructor(data, index) {
-    this.name = data.name;
-    this.url = data.url;
-    this.index = index;
-    this.buffer = undefined;
-  }
-
-  async load() {
-    // Return if buffer has been loaded already or there is nothing to load
-    // ("No effect" instance).
-    if (!this.url || this.buffer) {
-      return;
-    }
-
-    this.buffer = await fetchAudio(this.url);
+  for (const effect of EFFECTS) {
+    effect.load();
   }
 }
 
 function loadDemos(onDemoLoaded) {
   for (let demoIndex = 0; demoIndex < 5; demoIndex++) {
     const demo = DEMO_BEATS[demoIndex];
-    const effect = impulseResponses[demo.effectIndex];
+    const effect = EFFECTS[demo.effectIndex];
     const kit = KITS[demo.kitIndex];
 
     Promise.all([
@@ -132,21 +62,6 @@ function loadDemos(onDemoLoaded) {
       kit.load(),
     ]).then(() => onDemoLoaded(demoIndex));
   }
-}
-
-function loadAssets() {
-  // Any assets which have previously started loading will be skipped over.
-  for (const kit of KITS) {
-    kit.load();
-  }
-
-  for (const impulseResponse of impulseResponses) {
-    impulseResponse.load();
-  }
-}
-
-function getCurrentKit() {
-  return KITS[theBeat.kitIndex];
 }
 
 // This gets rid of the loading spinner in each of the demo buttons.
@@ -162,9 +77,14 @@ function onDemoLoaded(demoIndex) {
 }
 
 function init() {
-  impulseResponses = IMPULSE_RESPONSE_DATA.map(
-      (data, i) => new ImpulseResponse(data, i));
-  KITS = KIT_DATA.map(({id, name}) => new Kit(id, name));
+  EFFECTS.push(...IMPULSE_RESPONSE_DATA.map(
+      (data, i) => new Effect(data, i)));
+
+  KITS.push(...KIT_DATA.map(({id, name}, i) => new Kit(id, name, i)));
+
+  theBeat = new Beat(RESET_BEAT, KITS, EFFECTS);
+
+  player = new Player(theBeat, onNextBeat);
 
   initControls();
 
@@ -175,33 +95,6 @@ function init() {
 
   // Then load the remaining assets.
   loadAssets();
-
-  context = new AudioContext();
-
-  let finalMixNode;
-  if (context.createDynamicsCompressor) {
-    // Create a dynamics compressor to sweeten the overall mix.
-    compressor = context.createDynamicsCompressor();
-    compressor.connect(context.destination);
-    finalMixNode = compressor;
-  } else {
-    // No compressor available in this implementation.
-    finalMixNode = context.destination;
-  }
-
-  // Create master volume.
-  masterGainNode = context.createGain();
-  masterGainNode.gain.value = 0.7; // reduce overall volume to avoid clipping
-  masterGainNode.connect(finalMixNode);
-
-  // Create effect volume.
-  effectLevelNode = context.createGain();
-  effectLevelNode.gain.value = 1.0; // effect level slider controls this
-  effectLevelNode.connect(masterGainNode);
-
-  // Create convolver for effect
-  convolver = context.createConvolver();
-  convolver.connect(effectLevelNode);
 
   updateControls();
 }
@@ -214,17 +107,21 @@ function initControls() {
 
   ui.kitPicker = new KitPicker();
   ui.kitPicker.addOptions(KITS.map((kit) => kit.prettyName));
-  ui.kitPicker.onSelect = (i) => handleKitChange(i);
+  ui.kitPicker.onSelect = (i) => {
+    theBeat.kit = KITS[i];
+  };
 
   ui.effectPicker = new EffectPicker();
-  ui.effectPicker.addOptions(impulseResponses.map((e) => e.name));
-  ui.effectPicker.onSelect = (i) => handleEffectChange(i);
+  ui.effectPicker.addOptions(EFFECTS.map((e) => e.name));
+  ui.effectPicker.onSelect = (i) => {
+    setEffect(i);
+  };
 
   ui.effectSlider = new EffectSlider();
   ui.effectSlider.onchange = (value) => {
     // Change the volume of the convolution effect.
     theBeat.effectMix = value;
-    setEffectLevel(theBeat);
+    player.updateEffect();
   };
 
   ui.swingSlider = new SwingSlider();
@@ -233,7 +130,7 @@ function initControls() {
   };
 
   ui.pitchSliders = new PitchSliders();
-  ui.pitchSliders.onPitchChange = (instrumentName, pitch) => setPitch(
+  ui.pitchSliders.onPitchChange = (instrumentName, pitch) => theBeat.setPitch(
       instrumentName, pitch);
 
   ui.playButton = new PlayButton();
@@ -245,9 +142,11 @@ function initControls() {
     }
   };
 
-  ui.modal.save = new SaveModal(() => JSON.stringify(theBeat));
+  ui.modal.save = new SaveModal(() => JSON.stringify(theBeat.toObject()));
   ui.modal.load = new LoadModal();
-  ui.modal.load.onLoad = (data) => handleLoad(data);
+  ui.modal.load.onLoad = (data) => {
+    loadBeat(JSON.parse(data));
+  };
 
   ui.resetButton = new ResetButton();
   ui.resetButton.onclick = () => {
@@ -268,213 +167,62 @@ function initControls() {
   ui.playheads = new Playheads();
 }
 
-function setPitch(instrumentName, pitch) {
-  theBeat[`${instrumentName.toLowerCase()}PitchVal`] = pitch;
-}
-
-function getPitch(instrumentName) {
-  return theBeat[`${instrumentName.toLowerCase()}PitchVal`];
-}
-
-function getRhythm(instrumentName) {
-  const index = 1 + INSTRUMENTS.findIndex((i) => i.name === instrumentName);
-  return theBeat[`rhythm${index}`];
-}
-
-function advanceNote() {
-  // Advance time by a 16th note...
-  const secondsPerBeat = 60.0 / theBeat.tempo;
-
-  rhythmIndex++;
-  if (rhythmIndex == LOOP_LENGTH) {
-    rhythmIndex = 0;
-  }
-
-  // apply swing
-  if (rhythmIndex % 2) {
-    noteTime += (0.25 + MAX_SWING * theBeat.swingFactor) * secondsPerBeat;
-  } else {
-    noteTime += (0.25 - MAX_SWING * theBeat.swingFactor) * secondsPerBeat;
-  }
-}
-
-function playNote(instrument, rhythmIndex, noteTime) {
-  const note = getRhythm(instrument.name)[rhythmIndex];
-
-  if (!note) {
-    return;
-  }
-
-  // Create the note
-  const voice = context.createBufferSource();
-  voice.buffer = getCurrentKit().buffer[instrument.name];
-  voice.playbackRate.value = computePlaybackRate(instrument.name);
-
-  // Optionally, connect to a panner
-  let finalNode;
-  if (instrument.pan) {
-    const panner = context.createPanner();
-    // Pan according to sequence position.
-    panner.setPosition(0.5 * rhythmIndex - 4, 0, -1);
-    voice.connect(panner);
-    finalNode = panner;
-  } else {
-    finalNode = voice;
-  }
-
-  // Connect to dry mix
-  const dryGainNode = context.createGain();
-  dryGainNode.gain.value = VOLUMES[note] * instrument.mainGain * effectDryMix;
-  finalNode.connect(dryGainNode);
-  dryGainNode.connect(masterGainNode);
-
-  // Connect to wet mix
-  const wetGainNode = context.createGain();
-  wetGainNode.gain.value = instrument.sendGain;
-  finalNode.connect(wetGainNode);
-  wetGainNode.connect(convolver);
-
-  voice.start(noteTime);
-}
-
-function schedule() {
-  let currentTime = context.currentTime;
-
-  // The sequence starts at startTime, so normalize currentTime so that it's 0
-  // at the start of the sequence.
-  currentTime -= startTime;
-
-  while (noteTime < currentTime + 0.200) {
-    // Convert noteTime to context time.
-    const contextPlayTime = noteTime + startTime;
-
-    for (const instrument of INSTRUMENTS) {
-      playNote(instrument, rhythmIndex, contextPlayTime);
-    }
-
-    // Attempt to synchronize drawing time with sound
-    if (noteTime != lastDrawTime) {
-      lastDrawTime = noteTime;
-      ui.playheads.drawPlayhead((rhythmIndex + 15) % 16);
-    }
-
-    advanceNote();
-  }
-
-  timeoutId = setTimeout(schedule, 0);
-}
-
-function computePlaybackRate(instrumentName) {
-  const pitch = getPitch(instrumentName);
-  return Math.pow(2.0, 2.0 * (pitch - 0.5));
-}
-
 function handleNoteClick(instrumentName, rhythmIndex) {
-  const instrument = INSTRUMENTS.find((i) => i.name === instrumentName);
-  const notes = getRhythm(instrumentName);
-  const note = (notes[rhythmIndex] + 1) % 3;
-  notes[rhythmIndex] = note;
+  theBeat.toggleNote(instrumentName, rhythmIndex);
 
-  ui.notes.setNote(instrument.name, rhythmIndex, notes[rhythmIndex]);
+  ui.notes.setNote(instrumentName, rhythmIndex,
+      theBeat.getNote(instrumentName, rhythmIndex));
 
-  playNote(instrument, rhythmIndex, 0);
-}
-
-function handleKitChange(index) {
-  theBeat.kitIndex = index;
-}
-
-function handleEffectChange(index) {
-  // Hack - if effect is turned all the way down - turn up effect slider.
-  // ... since they just explicitly chose an effect from the list.
-  if (theBeat.effectMix == 0) {
-    theBeat.effectMix = 0.5;
-  }
-
-  setEffect(index);
+  const instrument = INSTRUMENTS.find((instr) => instr.name === instrumentName);
+  player.playNote(instrument, rhythmIndex);
 }
 
 async function setEffect(index) {
-  await impulseResponses[index].load();
+  const effect = EFFECTS[index];
+  await effect.load();
 
-  theBeat.effectIndex = index;
-  effectDryMix = IMPULSE_RESPONSE_DATA[index].dryMix;
-  effectWetMix = IMPULSE_RESPONSE_DATA[index].wetMix;
-  convolver.buffer = impulseResponses[index].buffer;
-
-  // Hack - if the effect is meant to be entirely wet (not unprocessed signal)
-  // then put the effect level all the way up.
-  if (effectDryMix == 0) {
-    theBeat.effectMix = 1;
-  }
-
-  setEffectLevel(theBeat);
+  theBeat.effect = effect;
+  player.updateEffect();
   updateControls();
-
-  ui.effectPicker.select(index);
-}
-
-function setEffectLevel() {
-  // Factor in both the preset's effect level and the blending level
-  // (effectWetMix) stored in the effect itself.
-  effectLevelNode.gain.value = theBeat.effectMix * effectWetMix;
 }
 
 function handlePlay() {
-  noteTime = 0.0;
-  startTime = context.currentTime + 0.005;
-  schedule();
-
+  player.play();
   ui.playButton.state = 'playing';
 }
 
 function handleStop() {
-  clearTimeout(timeoutId);
-
-  rhythmIndex = 0;
-
+  player.stop();
   ui.playheads.off();
   ui.playButton.state = 'stopped';
 }
 
-function handleLoad(data) {
-  theBeat = JSON.parse(data);
-
-  // Set effect
-  setEffect(theBeat.effectIndex);
-
-  // Change the volume of the convolution effect.
-  setEffectLevel(theBeat);
-
+function loadBeat(beat) {
+  handleStop();
+  theBeat.loadObject(beat);
+  player.updateEffect();
   updateControls();
 }
 
-function loadBeat(beat) {
-  handleStop();
-
-  theBeat = clone(beat);
-  setEffect(theBeat.effectIndex);
-
-  updateControls();
-
-  return true;
+function onNextBeat(rhythmIndex) {
+  ui.playheads.drawPlayhead(rhythmIndex);
 }
 
 function updateControls() {
   for (const instrument of INSTRUMENTS) {
-    const notes = getRhythm(instrument.name);
     for (let i = 0; i < LOOP_LENGTH; ++i) {
-      ui.notes.setNote(instrument.name, i, notes[i]);
+      ui.notes.setNote(instrument.name, i, theBeat.getNote(instrument.name, i));
     }
   }
 
-  ui.kitPicker.select(theBeat.kitIndex);
-  ui.effectPicker.select(theBeat.effectIndex);
+  ui.kitPicker.select(theBeat.kit.index);
+  ui.effectPicker.select(theBeat.effect.index);
   ui.tempoInput.value = theBeat.tempo;
   ui.effectSlider.value = theBeat.effectMix;
   ui.swingSlider.value = theBeat.swingFactor;
 
   for (const instrument of INSTRUMENTS) {
-    ui.pitchSliders.setPitch(instrument.name, getPitch(instrument.name));
+    ui.pitchSliders.setPitch(instrument.name,
+        theBeat.getPitch(instrument.name));
   }
 }

--- a/archive/demos/shiny-drum-machine.js
+++ b/archive/demos/shiny-drum-machine.js
@@ -7,7 +7,7 @@ import {DemoButtons, EffectPicker, KitPicker, EffectSlider, SwingSlider,
   PitchSliders, TempoInput, Playheads, Notes, SaveModal, LoadModal,
   ResetButton, PlayButton} from './shiny-drum-machine-ui.js';
 
-import {Beat, Player, Kit, Effect, LOOP_LENGTH} from './shiny-drum-machine-audio.js';
+import {Beat, Player, Kit, Effect} from './shiny-drum-machine-audio.js';
 
 
 // Events
@@ -210,9 +210,9 @@ function onNextBeat(rhythmIndex) {
 
 function updateControls() {
   for (const instrument of INSTRUMENTS) {
-    for (let i = 0; i < LOOP_LENGTH; ++i) {
-      ui.notes.setNote(instrument.name, i, theBeat.getNote(instrument.name, i));
-    }
+    theBeat.getNotes(instrument.name).forEach((note, i) => {
+      ui.notes.setNote(instrument.name, i, note);
+    });
   }
 
   ui.kitPicker.select(theBeat.kit.index);

--- a/archive/demos/style/drummachine.css
+++ b/archive/demos/style/drummachine.css
@@ -68,6 +68,16 @@ body {
 	margin-bottom: 12px;
 }
 
+.led {
+	width: 38px;
+	height: 9px;
+	background: url(../images/LED_off.png);
+}
+
+.led[data-led='on'] {
+	background-image: url(../images/LED_on.png);
+}
+
 .label {
 	display: inline-block;
 	width: 60px;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "web-audio-samples",
   "version": "2.1.0",
   "scripts": {
-    "lint": "eslint"
+    "lint": "eslint ."
   },
   "author": "Chromium authors",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Introduced Beat class to manage stateful beat data structure.
- Introduce Player class to schedule playback and handle audio routing.
- Refactor beat position LED display to decouple HTML and JS.
- Simplify audio scheduling logic.
- Ignore all pre-existing files that violate eslint in eslint config, so that `npm run lint .` can be executed in the repository without failing due to old files.

This concludes most refactorings for drum machine, let's discuss next steps on Thursday.

See #226  