### PR TITLE
Add example for AudioWorkletNode constructor options parameter

### DIFF
--- a/audio-worklet/PageData.js
+++ b/audio-worklet/PageData.js
@@ -53,7 +53,7 @@ export default {
         url: 'basic/message-port/',
       },
       {
-        title: 'AudioWorkletNode Options!',
+        title: 'AudioWorkletNode Options',
         description: `
             A simple AudioWorkletNode constructor example which passes options to processor`,
         url: 'basic/audio-worklet-node-options/',

--- a/audio-worklet/PageData.js
+++ b/audio-worklet/PageData.js
@@ -53,6 +53,12 @@ export default {
         url: 'basic/message-port/',
       },
       {
+        title: 'AudioWorkletNode Options!',
+        description: `
+            A simple AudioWorkletNode constructor example which passes options to processor`,
+        url: 'basic/audio-worklet-node-options/',
+      },
+      {
         title: 'Handling Errors',
         description: `How to handle errors from processor`,
         url: 'basic/handling-errors/',

--- a/audio-worklet/basic/audio-worklet-node-options/PageData.js
+++ b/audio-worklet/basic/audio-worklet-node-options/PageData.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2022 Google Inc. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -18,12 +18,12 @@ export default {
     pathData: [
       ['Home', '../../../'],
       ['AudioWorklet', '../../'],
-      ['AudioWorkletNode Options!'],
+      ['AudioWorkletNode Options'],
     ],
   },
 
   Description: {
-    title: 'AudioWorkletNode Options!!',
+    title: 'AudioWorkletNode Options',
     detail: `A simple AudioWorkletNode constructor example that passes type and freqency options to processor during creation.`
   },
 };

--- a/audio-worklet/basic/audio-worklet-node-options/PageData.js
+++ b/audio-worklet/basic/audio-worklet-node-options/PageData.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default {
+  TopBar: {
+    pathData: [
+      ['Home', '../../../'],
+      ['AudioWorklet', '../../'],
+      ['AudioWorkletNode Options!'],
+    ],
+  },
+
+  Description: {
+    title: 'AudioWorkletNode Options!!',
+    detail: `A simple AudioWorkletNode constructor example that passes type and freqency options to processor during creation.`
+  },
+};

--- a/audio-worklet/basic/audio-worklet-node-options/basic-processor.js
+++ b/audio-worklet/basic/audio-worklet-node-options/basic-processor.js
@@ -14,12 +14,14 @@ const sine = (frequency, time) => {
 
 // https://en.wikipedia.org/wiki/Square_wave
 const square = (frequency, time) => {
-  return 2 * (2 * Math.floor(frequency * time) - Math.floor(2 * frequency * time)) + 1
+  return 2 * 
+    (2 * Math.floor(frequency * time) - Math.floor(2 * frequency * time)) + 1
 }
 
 // https://en.wikipedia.org/wiki/Triangle_wave
 const triangle = (frequency, time) => {
-  return 2 * Math.abs(2 * (frequency * time - Math.floor(frequency * time + 0.5))) - 1
+  return 2 * 
+    Math.abs(2 * (frequency * time - Math.floor(frequency * time + 0.5))) - 1
 }
 
 const noise = () => {

--- a/audio-worklet/basic/audio-worklet-node-options/basic-processor.js
+++ b/audio-worklet/basic/audio-worklet-node-options/basic-processor.js
@@ -1,0 +1,66 @@
+
+// https://en.wikipedia.org/wiki/Sawtooth_wave
+const sawtooth = (f, t) => {
+  return 2 * (t * f - Math.floor(t * f + 0.5));
+}
+
+// https://en.wikipedia.org/wiki/Sine_wave
+const sine = (f, t) => {
+  return Math.sin(2 * Math.PI * f * t);
+}
+
+// https://en.wikipedia.org/wiki/Square_wave
+const square = (f, t) => {
+  return 2 * (2 * Math.floor(f * t) - Math.floor(2 * f * t)) + 1
+}
+
+// https://en.wikipedia.org/wiki/Triangle_wave
+const triangle = (f, t) => {
+  return 2 * Math.abs(2 * (f * t - Math.floor(f * t + 0.5))) - 1
+}
+
+const noise = () => {
+  return 2 * (Math.random() - 0.5);
+}
+
+class BasicProcessor extends AudioWorkletProcessor {
+  constructor(options) {
+      super();
+      this.sample = 0;
+      this.output_function = noise;
+      this.f = 440;
+      if (options.processorOptions) {
+          if (options.processorOptions.type == 'sine') {
+              this.output_function = sine;
+          } else if (options.processorOptions.type == 'sawtooth') {
+              this.output_function = sawtooth;
+          } else if (options.processorOptions.type == 'square') {
+              this.output_function = square;
+          } else if (options.processorOptions.type == 'triangle') {
+              this.output_function = triangle;
+          } else if (options.processorOptions.type == 'noise') {
+              this.output_function = noise;
+          }
+          this.f = options.processorOptions.frequency || 440;
+      }
+  }
+
+  process(inputs, outputs, parameters) {
+
+      const output = outputs[0];
+  
+
+      for (let channel = 0; channel < output.length; ++channel) {
+          const outputChannel = output[channel];
+          for (let i = 0; i < outputChannel.length; ++i) {
+              outputChannel[i] = this.output_function(this.f, this.sample/sampleRate);
+              this.sample++;
+              if (this.sample > sampleRate) this.sample = 0;
+          }
+      }
+
+      return true;
+  }
+}
+
+registerProcessor('basic-processor', BasicProcessor);

--- a/audio-worklet/basic/audio-worklet-node-options/basic-processor.js
+++ b/audio-worklet/basic/audio-worklet-node-options/basic-processor.js
@@ -63,8 +63,8 @@ class BasicProcessor extends AudioWorkletProcessor {
     for (let channel = 0; channel < output.length; ++channel) {
       const outputChannel = output[channel];
       for (let i = 0; i < outputChannel.length; ++i) {
-        outputChannel[i] = this.outputFunction(this.frequency, 
-          this.sample/sampleRate);
+        outputChannel[i] = 
+          this.outputFunction(this.frequency, this.sample/sampleRate);
         this.sample++;
         if (this.sample > sampleRate) this.sample = 0;
       }

--- a/audio-worklet/basic/audio-worklet-node-options/basic-processor.js
+++ b/audio-worklet/basic/audio-worklet-node-options/basic-processor.js
@@ -39,19 +39,19 @@ class BasicProcessor extends AudioWorkletProcessor {
   constructor(options) {
     super();
     this.sample = 0;
-    this.output_function = noise;
+    this.outputFunction = noise;
     this.frequency = 440;
     if (options.processorOptions) {
       if (options.processorOptions.type == 'sine') {
-          this.output_function = sine;
+          this.outputFunction = sine;
       } else if (options.processorOptions.type == 'sawtooth') {
-          this.output_function = sawtooth;
+          this.outputFunction = sawtooth;
       } else if (options.processorOptions.type == 'square') {
-          this.output_function = square;
+          this.outputFunction = square;
       } else if (options.processorOptions.type == 'triangle') {
-          this.output_function = triangle;
+          this.outputFunction = triangle;
       } else if (options.processorOptions.type == 'noise') {
-          this.output_function = noise;
+          this.outputFunction = noise;
       }
       this.frequency = options.processorOptions.frequency || 440;
     }
@@ -63,7 +63,7 @@ class BasicProcessor extends AudioWorkletProcessor {
     for (let channel = 0; channel < output.length; ++channel) {
       const outputChannel = output[channel];
       for (let i = 0; i < outputChannel.length; ++i) {
-        outputChannel[i] = this.output_function(this.frequency, 
+        outputChannel[i] = this.outputFunction(this.frequency, 
           this.sample/sampleRate);
         this.sample++;
         if (this.sample > sampleRate) this.sample = 0;

--- a/audio-worklet/basic/audio-worklet-node-options/basic-processor.js
+++ b/audio-worklet/basic/audio-worklet-node-options/basic-processor.js
@@ -1,65 +1,73 @@
+// Copyright (c) 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 // https://en.wikipedia.org/wiki/Sawtooth_wave
-const sawtooth = (f, t) => {
-  return 2 * (t * f - Math.floor(t * f + 0.5));
+const sawtooth = (frequency, time) => {
+  return 2 * (time * frequency - Math.floor(time * frequency + 0.5));
 }
 
 // https://en.wikipedia.org/wiki/Sine_wave
-const sine = (f, t) => {
-  return Math.sin(2 * Math.PI * f * t);
+const sine = (frequency, time) => {
+  return Math.sin(2 * Math.PI * frequency * time);
 }
 
 // https://en.wikipedia.org/wiki/Square_wave
-const square = (f, t) => {
-  return 2 * (2 * Math.floor(f * t) - Math.floor(2 * f * t)) + 1
+const square = (frequency, time) => {
+  return 2 * (2 * Math.floor(frequency * time) - Math.floor(2 * frequency * time)) + 1
 }
 
 // https://en.wikipedia.org/wiki/Triangle_wave
-const triangle = (f, t) => {
-  return 2 * Math.abs(2 * (f * t - Math.floor(f * t + 0.5))) - 1
+const triangle = (frequency, time) => {
+  return 2 * Math.abs(2 * (frequency * time - Math.floor(frequency * time + 0.5))) - 1
 }
 
 const noise = () => {
   return 2 * (Math.random() - 0.5);
 }
 
+
+/**
+ * A basic processor with constructor options for frequency and type.
+ *
+ * @class BasicProcessor
+ * @extends AudioWorkletProcessor
+ */
 class BasicProcessor extends AudioWorkletProcessor {
   constructor(options) {
-      super();
-      this.sample = 0;
-      this.output_function = noise;
-      this.f = 440;
-      if (options.processorOptions) {
-          if (options.processorOptions.type == 'sine') {
-              this.output_function = sine;
-          } else if (options.processorOptions.type == 'sawtooth') {
-              this.output_function = sawtooth;
-          } else if (options.processorOptions.type == 'square') {
-              this.output_function = square;
-          } else if (options.processorOptions.type == 'triangle') {
-              this.output_function = triangle;
-          } else if (options.processorOptions.type == 'noise') {
-              this.output_function = noise;
-          }
-          this.f = options.processorOptions.frequency || 440;
+    super();
+    this.sample = 0;
+    this.output_function = noise;
+    this.frequency = 440;
+    if (options.processorOptions) {
+      if (options.processorOptions.type == 'sine') {
+          this.output_function = sine;
+      } else if (options.processorOptions.type == 'sawtooth') {
+          this.output_function = sawtooth;
+      } else if (options.processorOptions.type == 'square') {
+          this.output_function = square;
+      } else if (options.processorOptions.type == 'triangle') {
+          this.output_function = triangle;
+      } else if (options.processorOptions.type == 'noise') {
+          this.output_function = noise;
       }
+      this.frequency = options.processorOptions.frequency || 440;
+    }
   }
 
   process(inputs, outputs, parameters) {
+    const output = outputs[0];
 
-      const output = outputs[0];
-  
-
-      for (let channel = 0; channel < output.length; ++channel) {
-          const outputChannel = output[channel];
-          for (let i = 0; i < outputChannel.length; ++i) {
-              outputChannel[i] = this.output_function(this.f, this.sample/sampleRate);
-              this.sample++;
-              if (this.sample > sampleRate) this.sample = 0;
-          }
+    for (let channel = 0; channel < output.length; ++channel) {
+      const outputChannel = output[channel];
+      for (let i = 0; i < outputChannel.length; ++i) {
+        outputChannel[i] = this.output_function(this.frequency, 
+          this.sample/sampleRate);
+        this.sample++;
+        if (this.sample > sampleRate) this.sample = 0;
       }
-
-      return true;
+    }
+    return true;
   }
 }
 

--- a/audio-worklet/basic/audio-worklet-node-options/index.html
+++ b/audio-worklet/basic/audio-worklet-node-options/index.html
@@ -33,8 +33,7 @@
       html, render,
       Component, WorkletIndicator, TopBar, Footer,
       OneColumnView
-    }
-      from '../../../assets/Components.js';
+    } from '../../../assets/Components.js';
 
     render(html`
       <div id="TopBar"></div>
@@ -88,7 +87,7 @@
       } else {
         element.innerText = 'START';
         if (context) {
-          context.suspend()
+          context.suspend();
           context.close();
         }
       }

--- a/audio-worklet/basic/audio-worklet-node-options/index.html
+++ b/audio-worklet/basic/audio-worklet-node-options/index.html
@@ -95,10 +95,10 @@
     }
     
     document.querySelector('#toogle').addEventListener('click', demoFunction);
-    document.querySelector('#demo-input-type').addEventListener('change', 
-      demoFunction);
-    document.querySelector('#demo-input-frequency').addEventListener('change', 
-      demoFunction);
+    document.querySelector('#demo-input-type')
+            .addEventListener('change', demoFunction);
+    document.querySelector('#demo-input-frequency')
+            .addEventListener('change', demoFunction);
   </script>
 </body>
 

--- a/audio-worklet/basic/audio-worklet-node-options/index.html
+++ b/audio-worklet/basic/audio-worklet-node-options/index.html
@@ -1,0 +1,106 @@
+<!--
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="mobile-web-app-capable" content="yes">
+  <link href="../../../assets/was-styles.css" rel="stylesheet">
+  <title>AudioWorkletNode Options! | WebAudio Samples</title>
+</head>
+
+<body>
+  <div class="container was-page-wrap"></div>
+  <script type="module">
+    import PageData from './PageData.js';
+
+    import {
+      html, render,
+      Component, WorkletIndicator, TopBar, Footer,
+      OneColumnView
+    }
+      from '../../../assets/Components.js';
+
+
+    render(html`
+      <div id="TopBar"></div>
+      <div id="WorkletIndicator"></div>
+      <div id="Description"></div>
+      <div id="DemoInput">
+        <label for="type">Type:</label>
+        <select name="type" id="demo-input-type">
+          <option value="noise">Noise</option>
+          <option value="sine">Sine</option>
+          <option value="square">Square</option>
+          <option value="triangle">Triangle</option>
+          <option value="sawtooth">Sawtooth</option>
+        </select>
+        <label for="frequency">Frequency (1 - 20000):</label>
+        <input type="number" name="frequency" id="demo-input-frequency" min="1" max="20000" value=440>
+      </div>
+      <br>
+      <div id="Runner">
+        <button id="toogle">START</button>
+      </div>
+      <div id="Footer"></div>`,
+      document.getElementsByClassName('container was-page-wrap')[0]);
+
+    Component.build('TopBar', TopBar, PageData.TopBar);
+    Component.build('WorkletIndicator', WorkletIndicator);
+    Component.build('Description', OneColumnView, PageData.Description);
+    Component.build('Footer', Footer);
+    Component.present();
+    let context;
+
+    const demoFunction = async (e) => {
+      const element = document.getElementById('toogle');
+      if (element.innerText === 'START' && e.target === element) {
+        element.innerText = 'STOP';
+        const type = document.querySelector('#demo-input-type').value;
+        const frequency = document.querySelector('#demo-input-frequency').value;
+        context = new AudioContext();
+
+        await context.audioWorklet.addModule('basic-processor.js');
+
+        const basicProcessor = new AudioWorkletNode(context, 'basic-processor', {
+          processorOptions: {
+            type: type,
+            frequency: frequency
+          }
+        });
+        basicProcessor.connect(context.destination);
+        context.resume();
+      } else {
+        element.innerText = 'START';
+        if (context) {
+          context.suspend()
+          context.close();
+        }
+      }
+    }
+
+    document.querySelector('#toogle').addEventListener('click', demoFunction);
+    document.querySelector('#demo-input-type').addEventListener('change', demoFunction);
+    document.querySelector('#demo-input-frequency').addEventListener('change', demoFunction);
+
+
+
+  </script>
+</body>
+
+</html>

--- a/audio-worklet/basic/audio-worklet-node-options/index.html
+++ b/audio-worklet/basic/audio-worklet-node-options/index.html
@@ -1,5 +1,5 @@
 <!--
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2022 Google Inc. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -36,7 +36,6 @@
     }
       from '../../../assets/Components.js';
 
-
     render(html`
       <div id="TopBar"></div>
       <div id="WorkletIndicator"></div>
@@ -51,7 +50,8 @@
           <option value="sawtooth">Sawtooth</option>
         </select>
         <label for="frequency">Frequency (1 - 20000):</label>
-        <input type="number" name="frequency" id="demo-input-frequency" min="1" max="20000" value=440>
+        <input type="number" name="frequency" id="demo-input-frequency" min="1" 
+          max="20000" value=440>
       </div>
       <br>
       <div id="Runner">
@@ -93,13 +93,12 @@
         }
       }
     }
-
+    
     document.querySelector('#toogle').addEventListener('click', demoFunction);
-    document.querySelector('#demo-input-type').addEventListener('change', demoFunction);
-    document.querySelector('#demo-input-frequency').addEventListener('change', demoFunction);
-
-
-
+    document.querySelector('#demo-input-type').addEventListener('change', 
+      demoFunction);
+    document.querySelector('#demo-input-frequency').addEventListener('change', 
+      demoFunction);
   </script>
 </body>
 


### PR DESCRIPTION
I wrote this example for issue regarding #131 .
In this example we can pass type and frequency options to AudioWorkletNode constructor and use those in AudioWorkletProcessor.

Here is how it looks like.
https://divyamahuja.github.io/web-audio-samples/audio-worklet/basic/audio-worklet-node-options/ 

I wonder if this will work for #131 issue