### PR TITLE
Add basic FreeQueue example

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,10 @@
   "ignorePatterns": [
     "_site/**/*.wasm.js",
     "_site/**/*.wasmmodule.js",
-    "_site/archive/"
+    "_site/archive/",
+    "_site/**/build/*",
+    "_site/**/coi-serviceworker.js",
+    "_site/**/build/*.js"
   ],
   "parserOptions": {
     "ecmaVersion": 12,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,8 +12,7 @@
     "_site/**/*.wasmmodule.js",
     "_site/archive/",
     "_site/**/build/*",
-    "_site/**/coi-serviceworker.js",
-    "_site/**/build/*.js"
+    "_site/**/coi-serviceworker.js"
   ],
   "parserOptions": {
     "ecmaVersion": 12,

--- a/src/_data/audioworklet_data.yaml
+++ b/src/_data/audioworklet_data.yaml
@@ -43,6 +43,12 @@
       description: For high performance large-scale audio applications
       href: design-pattern/shared-buffer/
 
+- title: FreeQueue
+  entries:
+    - title: Simple Passthrough
+      description: Basic example of FreeQueue and a worker thread.
+      href: free-queue/examples/simple-passthrough
+
 - title: Migration from ScriptProcessorNode
   entries: 
     - title: ScriptProcessorNode Recorder

--- a/src/_data/audioworklet_data.yaml
+++ b/src/_data/audioworklet_data.yaml
@@ -47,7 +47,11 @@
   entries:
     - title: Simple Passthrough
       description: Basic example of FreeQueue and a worker thread.
-      href: free-queue/examples/simple-passthrough
+        FreeQueue is a lock-free ring buffer library for high-performance 
+        audio processing designed to be used on top of the Web Audio API.
+        This example demonstrates how this library can be used as a channel
+        between a worker thread and AudioWorklet to send audio data.
+      href: free-queue/examples/simple-passthrough/
 
 - title: Migration from ScriptProcessorNode
   entries: 

--- a/src/_data/build_info.json
+++ b/src/_data/build_info.json
@@ -1,1 +1,1 @@
-{"version":"3.0.2","revision":"8422daa","lastUpdated":"2022-08-29","copyrightYear":2022}
+{"version":"3.0.2","revision":"2838fd6","lastUpdated":"2022-08-30","copyrightYear":2022}

--- a/src/_data/build_info.json
+++ b/src/_data/build_info.json
@@ -1,1 +1,1 @@
-{"version":"3.0.2","revision":"a484ed9","lastUpdated":"2022-08-10","copyrightYear":2022}
+{"version":"3.0.2","revision":"3eb4553","lastUpdated":"2022-08-20","copyrightYear":2022}

--- a/src/_data/build_info.json
+++ b/src/_data/build_info.json
@@ -1,1 +1,1 @@
-{"version":"3.0.2","revision":"3eb4553","lastUpdated":"2022-08-20","copyrightYear":2022}
+{"version":"3.0.2","revision":"8422daa","lastUpdated":"2022-08-29","copyrightYear":2022}

--- a/src/audio-worklet/free-queue/examples/simple-passthrough/basic-processor.js
+++ b/src/audio-worklet/free-queue/examples/simple-passthrough/basic-processor.js
@@ -1,0 +1,48 @@
+import FreeQueue from "../../src/free-queue.js";
+import { FRAME_SIZE, RENDER_QUANTUM } from "./constants.js";
+
+/**
+ * A simple AudioWorkletProcessor node.
+ *
+ * @class BasicProcessor
+ * @extends AudioWorkletProcessor
+ */
+class BasicProcessor extends AudioWorkletProcessor {
+  /**
+   * Constructor to initialize, input and output FreeQueue instances
+   * and atomicState to synchronise Worker with AudioWorklet
+   * @param {Object} options AudioWorkletProcessor options
+   *    to initialize inputQueue, outputQueue and atomicState
+   */
+  constructor(options) {
+    super();
+
+    this.inputQueue = options.processorOptions.inputQueue;
+    this.outputQueue = options.processorOptions.outputQueue;
+    this.atomicState = options.processorOptions.atomicState;
+    Object.setPrototypeOf(this.inputQueue, FreeQueue.prototype);
+    Object.setPrototypeOf(this.outputQueue, FreeQueue.prototype);
+
+  }
+
+  process(inputs, outputs) {
+    const input = inputs[0];
+    const output = outputs[0];
+    
+    // Push input into inputQueue.
+    this.inputQueue.push(input, RENDER_QUANTUM);
+    
+    // Try to pull data out of outputQueue and set it to output.
+    const didPull = this.outputQueue.pull(output, RENDER_QUANTUM);
+    if (!didPull) console.log("failed to pull")
+    
+    // Wake up worker to process a frame of data.
+    if (this.inputQueue.isFrameAvailable(FRAME_SIZE)) {
+      Atomics.notify(this.atomicState, 0, 1);
+    }
+    
+    return true;
+  }
+}
+
+registerProcessor('basic-processor', BasicProcessor);

--- a/src/audio-worklet/free-queue/examples/simple-passthrough/basic-processor.js
+++ b/src/audio-worklet/free-queue/examples/simple-passthrough/basic-processor.js
@@ -29,12 +29,14 @@ class BasicProcessor extends AudioWorkletProcessor {
     const input = inputs[0];
     const output = outputs[0];
     
-    // Push input into inputQueue.
+    // Push data from input into inputQueue.
     this.inputQueue.push(input, RENDER_QUANTUM);
     
-    // Try to pull data out of outputQueue and set it to output.
+    // Try to pull data out of outputQueue and store it in output.
     const didPull = this.outputQueue.pull(output, RENDER_QUANTUM);
-    if (!didPull) console.log("failed to pull")
+    if (!didPull) {
+      console.log("failed to pull.");
+    }
     
     // Wake up worker to process a frame of data.
     if (this.inputQueue.isFrameAvailable(FRAME_SIZE)) {

--- a/src/audio-worklet/free-queue/examples/simple-passthrough/coi-serviceworker.js
+++ b/src/audio-worklet/free-queue/examples/simple-passthrough/coi-serviceworker.js
@@ -1,0 +1,115 @@
+/*! coi-serviceworker v0.1.6 - Guido Zuidhof, licensed under MIT */
+let coepCredentialless = false;
+if (typeof window === 'undefined') {
+    self.addEventListener("install", () => self.skipWaiting());
+    self.addEventListener("activate", (event) => event.waitUntil(self.clients.claim()));
+
+    self.addEventListener("message", (ev) => {
+        if (!ev.data) {
+            return;
+        } else if (ev.data.type === "deregister") {
+            self.registration
+                .unregister()
+                .then(() => {
+                    return self.clients.matchAll();
+                })
+                .then(clients => {
+                    clients.forEach((client) => client.navigate(client.url));
+                });
+        } else if (ev.data.type === "coepCredentialless") {
+            coepCredentialless = ev.data.value;
+        }
+    });
+
+    self.addEventListener("fetch", function (event) {
+        const r = event.request;
+        if (r.cache === "only-if-cached" && r.mode !== "same-origin") {
+            return;
+        }
+
+        const request = (coepCredentialless && r.mode === "no-cors")
+            ? new Request(r, {
+                credentials: "omit",
+            })
+            : r;
+        event.respondWith(
+            fetch(request)
+                .then((response) => {
+                    if (response.status === 0) {
+                        return response;
+                    }
+
+                    const newHeaders = new Headers(response.headers);
+                    newHeaders.set("Cross-Origin-Embedder-Policy",
+                        coepCredentialless ? "credentialless" : "require-corp"
+                    );
+                    newHeaders.set("Cross-Origin-Opener-Policy", "same-origin");
+
+                    return new Response(response.body, {
+                        status: response.status,
+                        statusText: response.statusText,
+                        headers: newHeaders,
+                    });
+                })
+                .catch((e) => console.error(e))
+        );
+    });
+
+} else {
+    (() => {
+        // You can customize the behavior of this script through a global `coi` variable.
+        const coi = {
+            shouldRegister: () => true,
+            shouldDeregister: () => false,
+            coepCredentialless: () => false,
+            doReload: () => window.location.reload(),
+            quiet: false,
+            ...window.coi
+        };
+
+        const n = navigator;
+
+        if (n.serviceWorker && n.serviceWorker.controller) {
+            n.serviceWorker.controller.postMessage({
+                type: "coepCredentialless",
+                value: coi.coepCredentialless(),
+            });
+
+            if (coi.shouldDeregister()) {
+                n.serviceWorker.controller.postMessage({ type: "deregister" });
+            }
+        }
+
+        // If we're already coi: do nothing. Perhaps it's due to this script doing its job, or COOP/COEP are
+        // already set from the origin server. Also if the browser has no notion of crossOriginIsolated, just give up here.
+        if (window.crossOriginIsolated !== false || !coi.shouldRegister()) return;
+
+        if (!window.isSecureContext) {
+            !coi.quiet && console.log("COOP/COEP Service Worker not registered, a secure context is required.");
+            return;
+        }
+
+        // In some environments (e.g. Chrome incognito mode) this won't be available
+        if (n.serviceWorker) {
+            n.serviceWorker.register(window.document.currentScript.src).then(
+                (registration) => {
+                    !coi.quiet && console.log("COOP/COEP Service Worker registered", registration.scope);
+
+                    registration.addEventListener("updatefound", () => {
+                        !coi.quiet && console.log("Reloading page to make use of updated COOP/COEP Service Worker.");
+                        coi.doReload();
+                    });
+
+                    // If the registration is active, but it's not controlling the page
+                    if (registration.active && !n.serviceWorker.controller) {
+                        !coi.quiet && console.log("Reloading page to make use of COOP/COEP Service Worker.");
+                        coi.doReload();
+                    }
+                },
+                (err) => {
+                    !coi.quiet && console.error("COOP/COEP Service Worker failed to register:", err);
+                }
+            );
+        }
+    })();
+}

--- a/src/audio-worklet/free-queue/examples/simple-passthrough/constants.js
+++ b/src/audio-worklet/free-queue/examples/simple-passthrough/constants.js
@@ -1,0 +1,4 @@
+export const KERNEL_LENGTH = 20;
+export const RENDER_QUANTUM = 128;
+export const FRAME_SIZE = KERNEL_LENGTH * RENDER_QUANTUM;
+export const QUEUE_SIZE = 40960;

--- a/src/audio-worklet/free-queue/examples/simple-passthrough/constants.js
+++ b/src/audio-worklet/free-queue/examples/simple-passthrough/constants.js
@@ -2,3 +2,4 @@ export const KERNEL_LENGTH = 20;
 export const RENDER_QUANTUM = 128;
 export const FRAME_SIZE = KERNEL_LENGTH * RENDER_QUANTUM;
 export const QUEUE_SIZE = 40960;
+

--- a/src/audio-worklet/free-queue/examples/simple-passthrough/index.njk
+++ b/src/audio-worklet/free-queue/examples/simple-passthrough/index.njk
@@ -22,14 +22,11 @@ to_root_dir: ../../../../
     target="_blank">Chrome Developers Article: Audio Worklet Design Pattern</a>
   for more details.</p>
 
-<p> TODO: Write an article about this pattern.</p>
 <div class="demo-box">
-  <button id="toogle" disabled>TOOGLE</button>
+  <button id="toggle" disabled>TOGGLE</button>
   {% include to_root_dir + "_includes/example-source-code.njk" %}
 </div>
 
 <script src="./main.js" type="module" defer></script>
 
 {% endblock %}
-
-

--- a/src/audio-worklet/free-queue/examples/simple-passthrough/index.njk
+++ b/src/audio-worklet/free-queue/examples/simple-passthrough/index.njk
@@ -23,7 +23,7 @@ to_root_dir: ../../../../
   for more details.</p>
 
 <div class="demo-box">
-  <button id="toggle" disabled>TOGGLE</button>
+  <button id="toggle" disabled>START</button>
   {% include to_root_dir + "_includes/example-source-code.njk" %}
 </div>
 

--- a/src/audio-worklet/free-queue/examples/simple-passthrough/index.njk
+++ b/src/audio-worklet/free-queue/examples/simple-passthrough/index.njk
@@ -1,0 +1,35 @@
+---
+eleventyNavigation:
+  key: simple-passthrough
+  title: Simple Passthrough Example
+  parent: audio-worklet
+to_root_dir: ../../../../
+---
+
+{% extends to_root_dir + "_includes/base.njk" %}
+
+{% block content %}
+
+<script src="./coi-serviceworker.js"></script>
+
+<h1>{{ eleventyNavigation.title }}</h1>
+<p>This example demonstrates how to take advantage of Worker thread and 
+  FreeQueue in conjunction with AudioWorklet. FreeQueue is being used here to 
+  exchange data between AudioWorklet and Worker thread.
+</p>
+<p>See
+  <a href="https://developer.chrome.com/blog/audio-worklet-design-pattern/"
+    target="_blank">Chrome Developers Article: Audio Worklet Design Pattern</a>
+  for more details.</p>
+
+<p> TODO: Write an article about this pattern.</p>
+<div class="demo-box">
+  <button id="toogle" disabled>TOOGLE</button>
+  {% include to_root_dir + "_includes/example-source-code.njk" %}
+</div>
+
+<script src="./main.js" type="module" defer></script>
+
+{% endblock %}
+
+

--- a/src/audio-worklet/free-queue/examples/simple-passthrough/main.js
+++ b/src/audio-worklet/free-queue/examples/simple-passthrough/main.js
@@ -32,7 +32,9 @@ const createAudioContext = async () => {
         }
       });
   oscillator.connect(processorNode).connect(audioContext.destination);
+  // Initially suspend audioContext so it can be toggled on and off later.
   audioContext.suspend();
+  // Start the oscillator
   oscillator.start();
   console.log('AudioContext created.');
   return audioContext;
@@ -44,24 +46,31 @@ const createAudioContext = async () => {
  * It toggles audio state between playing and paused.
  */
 const toggleButtonClickHandler = async () => {
+  // If AudioContext doesn't exist, try creating one. 
   if (!audioContext) {
     try {
       audioContext = await createAudioContext();
     } catch(error) {
+      // If AudioContext creation fails, disable toggle button and
+      // log error to console
       toggleButton.disabled = true;
       console.error(error);
       return;
     }
   }
-
+  // If the audio is currently not playing, then on button click resume 
+  // playing audio, otherwise if the audio is playing then on button click
+  // suspend playing.
   if (!isPlaying) {
     audioContext.resume();
     isPlaying = true;
     toggleButton.style.backgroundColor = 'red';
+    toggleButton.innerHTML = 'STOP';
   } else {
     audioContext.suspend();
     isPlaying = false;
     toggleButton.style.backgroundColor = 'green';
+    toggleButton.innerHTML = 'START';
   }
 };
 

--- a/src/audio-worklet/free-queue/examples/simple-passthrough/main.js
+++ b/src/audio-worklet/free-queue/examples/simple-passthrough/main.js
@@ -1,0 +1,79 @@
+import FreeQueue from "../../src/free-queue.js"
+import { QUEUE_SIZE } from "./constants.js";
+
+const toogleButton = document.getElementById("toogle");
+toogleButton.disabled = false;
+
+// Create 2 FreeQueue instances with 4096 buffer length and 1 channel.
+const inputQueue = new FreeQueue(QUEUE_SIZE, 1);
+const outputQueue = new FreeQueue(QUEUE_SIZE, 1);
+// Create an atomic state for synchronization between worker and AudioWorklet.
+const atomicState = new Int32Array(
+    new SharedArrayBuffer(1 * Int32Array.BYTES_PER_ELEMENT)
+);
+
+let audioContext;
+let playing = false;
+
+/**
+ * Function to create and initialize AudioContext.
+ * @returns {Promise<AudioContext>}
+ */
+const createAudioContext = async () => {
+  const audioContext = new AudioContext();
+  await audioContext.audioWorklet.addModule("basic-processor.js");
+  const oscillator = new OscillatorNode(audioContext);
+  const processorNode =
+      new AudioWorkletNode(audioContext, 'basic-processor', {
+          processorOptions: {
+              inputQueue,
+              outputQueue,
+              atomicState
+          }
+      });
+  oscillator.connect(processorNode).connect(audioContext.destination);
+  audioContext.suspend();
+  oscillator.start();
+  console.log("AudioContext created.");
+  return audioContext;
+}
+
+/**
+ * Function to run, when toogle button is clicked.
+ * It creates AudioContext, first time button is clicked.
+ * It toogles audio state between playing and paused.
+ */
+const toogleButtonClickHandler = async () => {
+  if (!audioContext) {
+    try {
+      audioContext = await createAudioContext();
+    } catch(error) {
+      console.error(error);
+      return;
+    }
+  }
+
+  if (!playing) {
+    audioContext.resume();
+    playing = true;
+  } else {
+    audioContext.suspend();
+    playing = false;
+  }
+}
+
+toogleButton.onclick = toogleButtonClickHandler;
+
+// Create a WebWorker for Audio Processing.
+const worker = new Worker("worker.js", { type: "module"});
+
+
+// Send FreeQueue instance and atomic state to worker.
+worker.postMessage({
+    type: "init",
+    data: {
+        inputQueue,
+        outputQueue,
+        atomicState
+    }
+})

--- a/src/audio-worklet/free-queue/examples/simple-passthrough/main.js
+++ b/src/audio-worklet/free-queue/examples/simple-passthrough/main.js
@@ -1,8 +1,8 @@
-import FreeQueue from "../../src/free-queue.js"
-import { QUEUE_SIZE } from "./constants.js";
+import FreeQueue from '../../src/free-queue.js'
+import { QUEUE_SIZE } from './constants.js';
 
-const toogleButton = document.getElementById("toogle");
-toogleButton.disabled = false;
+const toggleButton = document.getElementById('toggle');
+toggleButton.disabled = false;
 
 // Create 2 FreeQueue instances with 4096 buffer length and 1 channel.
 const inputQueue = new FreeQueue(QUEUE_SIZE, 1);
@@ -12,8 +12,8 @@ const atomicState = new Int32Array(
     new SharedArrayBuffer(1 * Int32Array.BYTES_PER_ELEMENT)
 );
 
-let audioContext;
-let playing = false;
+let audioContext = null;
+let isPlaying = false;
 
 /**
  * Function to create and initialize AudioContext.
@@ -21,59 +21,62 @@ let playing = false;
  */
 const createAudioContext = async () => {
   const audioContext = new AudioContext();
-  await audioContext.audioWorklet.addModule("basic-processor.js");
+  await audioContext.audioWorklet.addModule('basic-processor.js');
   const oscillator = new OscillatorNode(audioContext);
   const processorNode =
       new AudioWorkletNode(audioContext, 'basic-processor', {
-          processorOptions: {
-              inputQueue,
-              outputQueue,
-              atomicState
-          }
+        processorOptions: {
+          inputQueue,
+          outputQueue,
+          atomicState
+        }
       });
   oscillator.connect(processorNode).connect(audioContext.destination);
   audioContext.suspend();
   oscillator.start();
-  console.log("AudioContext created.");
+  console.log('AudioContext created.');
   return audioContext;
-}
+};
 
 /**
- * Function to run, when toogle button is clicked.
+ * Function to run, when toggle button is clicked.
  * It creates AudioContext, first time button is clicked.
- * It toogles audio state between playing and paused.
+ * It toggles audio state between playing and paused.
  */
-const toogleButtonClickHandler = async () => {
+const toggleButtonClickHandler = async () => {
   if (!audioContext) {
     try {
       audioContext = await createAudioContext();
     } catch(error) {
+      toggleButton.disabled = true;
       console.error(error);
       return;
     }
   }
 
-  if (!playing) {
+  if (!isPlaying) {
     audioContext.resume();
-    playing = true;
+    isPlaying = true;
+    toggleButton.style.backgroundColor = 'red';
   } else {
     audioContext.suspend();
-    playing = false;
+    isPlaying = false;
+    toggleButton.style.backgroundColor = 'green';
   }
-}
+};
 
-toogleButton.onclick = toogleButtonClickHandler;
+toggleButton.onclick = toggleButtonClickHandler;
 
 // Create a WebWorker for Audio Processing.
-const worker = new Worker("worker.js", { type: "module"});
+const worker = new Worker('worker.js', { type: 'module'});
 
 
 // Send FreeQueue instance and atomic state to worker.
 worker.postMessage({
-    type: "init",
-    data: {
-        inputQueue,
-        outputQueue,
-        atomicState
-    }
-})
+  type: 'init',
+  data: {
+    inputQueue,
+    outputQueue,
+    atomicState
+  }
+});

--- a/src/audio-worklet/free-queue/examples/simple-passthrough/worker.js
+++ b/src/audio-worklet/free-queue/examples/simple-passthrough/worker.js
@@ -1,0 +1,38 @@
+import FreeQueue from "../../src/free-queue.js";
+import { FRAME_SIZE } from "./constants.js";
+
+let queue;
+let atomicState;
+
+/**
+ * Worker message event handler.
+ * This will initialize worker with FreeQueue instance and set loop for audio
+ * processing. 
+ */
+self.onmessage = (msg) => {
+  if (msg.data.type === "init") {
+    let { inputQueue, outputQueue, atomicState } = msg.data.data;
+    Object.setPrototypeOf(inputQueue, FreeQueue.prototype);
+    Object.setPrototypeOf(outputQueue, FreeQueue.prototype);
+    
+    // buffer for storing data pulled out from queue.
+    const input = new Float32Array(FRAME_SIZE);
+    // loop for processing data.
+    while (Atomics.wait(atomicState, 0, 0) === 'ok') {
+      
+      // pull data out from inputQueue.
+      const didPull = inputQueue.pull([input], FRAME_SIZE);
+      
+      if (didPull) {
+        /**
+         * If pulling data out was successfull, process it and push it to
+         * outputQueue
+         */
+        const output = input.map(sample => 0.1 * sample);
+        outputQueue.push([output], FRAME_SIZE);
+      } 
+
+      Atomics.store(atomicState, 0, 0);
+    }
+  }
+}

--- a/src/audio-worklet/free-queue/examples/simple-passthrough/worker.js
+++ b/src/audio-worklet/free-queue/examples/simple-passthrough/worker.js
@@ -21,10 +21,8 @@ self.onmessage = (msg) => {
       const didPull = inputQueue.pull([input], FRAME_SIZE);
       
       if (didPull) {
-        /**
-         * If pulling data out was successfull, process it and push it to
-         * outputQueue
-         */
+        // If pulling data out was successfull, process it and push it to
+        // outputQueue
         const output = input.map(sample => 0.1 * sample);
         outputQueue.push([output], FRAME_SIZE);
       } 
@@ -32,4 +30,4 @@ self.onmessage = (msg) => {
       Atomics.store(atomicState, 0, 0);
     }
   }
-}
+};

--- a/src/audio-worklet/free-queue/examples/simple-passthrough/worker.js
+++ b/src/audio-worklet/free-queue/examples/simple-passthrough/worker.js
@@ -1,9 +1,6 @@
 import FreeQueue from "../../src/free-queue.js";
 import { FRAME_SIZE } from "./constants.js";
 
-let queue;
-let atomicState;
-
 /**
  * Worker message event handler.
  * This will initialize worker with FreeQueue instance and set loop for audio


### PR DESCRIPTION
This PR adds an basic example of FreeQueue.
In this example, audio data is sent to worker through inputQueue (FreeQueue Instance), and then is processed by worker(each sample is multiplied by 0.5), and is pushed to outputQueue(FreeQueue Instance).
AudioWorklet then pulls data out of outputQueue and renders it.

I also added [coi-serviceworker.js](https://github.com/gzuidhof/coi-serviceworker) to make it workable with GitHub pages.

Working Example - [Example](https://divyam.dev/web-audio-samples/audio-worklet/free-queue/examples/simple-passthrough/)