### PR TITLE
Fix broken link to view example source code.

### DIFF
--- a/src/_data/global_data.yaml
+++ b/src/_data/global_data.yaml
@@ -1,1 +1,1 @@
-githubUrl: https://github.com/GoogleChromeLabs/web-audio-samples/tree/main
+githubUrl: https://github.com/GoogleChromeLabs/web-audio-samples/tree/main/src


### PR DESCRIPTION
Currently if you go to https://googlechromelabs.github.io/web-audio-samples/audio-worklet/basic/hello-audio-worklet/ and click the "source code" link, it takes you to https://github.com/GoogleChromeLabs/web-audio-samples/tree/main/audio-worklet/basic/hello-audio-worklet/, which Github returns 404 Not Found for.  Changing .../tree/main/... to .../tree/main/src/... fixes the broken link (points to https://github.com/GoogleChromeLabs/web-audio-samples/tree/main/src/audio-worklet/basic/hello-audio-worklet/)