### PR TITLE
Fixing the bug in AudioWorklet Recorder demo

### DIFF
--- a/src/_data/build_info.json
+++ b/src/_data/build_info.json
@@ -1,1 +1,1 @@
-{"version":"3.0.2","revision":"d45625a","lastUpdated":"2023-04-20","copyrightYear":2023}
+{"version":"3.0.2","revision":"bd7d1bb","lastUpdated":"2023-04-20","copyrightYear":2023}

--- a/src/_data/build_info.json
+++ b/src/_data/build_info.json
@@ -1,1 +1,1 @@
-{"version":"3.0.2","revision":"1fe3f40","lastUpdated":"2023-04-12","copyrightYear":2023}
+{"version":"3.0.2","revision":"9931b45","lastUpdated":"2023-04-20","copyrightYear":2023}

--- a/src/_data/build_info.json
+++ b/src/_data/build_info.json
@@ -1,1 +1,1 @@
-{"version":"3.0.2","revision":"be371c1","lastUpdated":"2023-04-03","copyrightYear":2023}
+{"version":"3.0.2","revision":"1fe3f40","lastUpdated":"2023-04-12","copyrightYear":2023}

--- a/src/_data/build_info.json
+++ b/src/_data/build_info.json
@@ -1,1 +1,1 @@
-{"version":"3.0.2","revision":"9931b45","lastUpdated":"2023-04-20","copyrightYear":2023}
+{"version":"3.0.2","revision":"d45625a","lastUpdated":"2023-04-20","copyrightYear":2023}

--- a/src/audio-worklet/migration/worklet-recorder/app.js
+++ b/src/audio-worklet/migration/worklet-recorder/app.js
@@ -328,6 +328,7 @@ const createRecord = (recordingProperties, recordingLength, sampleRate,
 
   player.src = recordingUrl;
   downloadLink.src = recordingUrl;
-  downloadLink.download = 'recording-' + new Date().getMilliseconds().toString() + '.wav';
+  downloadLink.download =
+    `recording-${new Date().getMilliseconds().toString()}.wav`;
   downloadButton.disabled = false;
 };

--- a/src/audio-worklet/migration/worklet-recorder/app.js
+++ b/src/audio-worklet/migration/worklet-recorder/app.js
@@ -40,7 +40,7 @@ async function init() {
   const recordingProperties = {
     numberOfChannels: micSourceNode.channelCount,
     sampleRate: context.sampleRate,
-    maxFrameCount: context.sampleRate*10,
+    maxFrameCount: context.sampleRate*300,
   };
 
   const recordingNode = await setupRecordingWorkletNode(recordingProperties);
@@ -105,7 +105,8 @@ function handleRecording(processorPort, recordingProperties) {
   const recordButton = document.querySelector('#record');
   const recordText = recordButton.querySelector('span');
   const player = document.querySelector('#player');
-  const downloadButton = document.querySelector('#download');
+  const downloadLink = document.querySelector('#download-link');
+  const downloadButton = document.querySelector('#download-button');
 
   let recordingLength = 0;
 
@@ -113,8 +114,9 @@ function handleRecording(processorPort, recordingProperties) {
   const recordingEventCallback = async (event) => {
     if (event.data.message === 'MAX_RECORDING_LENGTH_REACHED') {
       isRecording = false;
-      recordText.innerHTML = 'Start';
-      recordButton.setAttribute.disabled = true;
+      recordText.innerHTML = 'Ready to download 5 mins';
+      recordButton.disabled = true;
+      createRecord(recordingProperties, recordingLength, context.sampleRate, downloadLink, downloadButton, event.data.buffer);
     }
     if (event.data.message === 'UPDATE_RECORDING_LENGTH') {
       recordingLength = event.data.recordingLength;
@@ -123,22 +125,7 @@ function handleRecording(processorPort, recordingProperties) {
           Math.round(recordingLength / context.sampleRate * 100)/100;
     }
     if (event.data.message === 'SHARE_RECORDING_BUFFER') {
-      const recordingBuffer = context.createBuffer(
-          recordingProperties.numberOfChannels,
-          recordingLength,
-          context.sampleRate);
-
-      for (let i = 0; i < recordingProperties.numberOfChannels; i++) {
-        recordingBuffer.copyToChannel(event.data.buffer[i], i, 0);
-      }
-
-      const wavUrl = createLinkFromAudioBuffer(
-          recordingBuffer,
-          true);
-
-      player.src = wavUrl;
-      downloadButton.src = wavUrl;
-      downloadButton.download = 'recording.wav';
+      createRecord(recordingProperties, recordingLength, context.sampleRate, downloadLink, downloadButton, event.data.buffer);
     }
   };
 
@@ -152,6 +139,7 @@ function handleRecording(processorPort, recordingProperties) {
     });
 
     recordText.innerHTML = isRecording ? 'Stop' : 'Start';
+    downloadButton.disabled = isRecording ? true : false;
   });
 
   return recordingEventCallback;
@@ -310,3 +298,27 @@ function setupRecordingGainVis() {
 
   return draw;
 }
+
+/**
+ * Creating the downloadable .wav file for the recorded voice and set
+ * the download button clickable.
+ */
+function createRecord(recordingProperties, recordingLength, sampleRate, downloadLink, downloadButton, dataBuffer) {
+  const recordingBuffer = context.createBuffer(
+      recordingProperties.numberOfChannels,
+      recordingLength,
+      sampleRate);
+
+  for (let i = 0; i < recordingProperties.numberOfChannels; i++) {
+    recordingBuffer.copyToChannel(dataBuffer[i], i, 0);
+  }
+
+  const wavUrl = createLinkFromAudioBuffer(
+      recordingBuffer,
+      true);
+
+  player.src = wavUrl;
+  downloadLink.src = wavUrl;
+  downloadLink.download = 'recording.wav';
+  downloadButton.disabled = false;
+};

--- a/src/audio-worklet/migration/worklet-recorder/app.js
+++ b/src/audio-worklet/migration/worklet-recorder/app.js
@@ -116,7 +116,8 @@ function handleRecording(processorPort, recordingProperties) {
       isRecording = false;
       recordText.innerHTML = 'Ready to download 5 mins';
       recordButton.disabled = true;
-      createRecord(recordingProperties, recordingLength, context.sampleRate, downloadLink, downloadButton, event.data.buffer);
+      createRecord(recordingProperties, recordingLength, context.sampleRate,
+        downloadLink, downloadButton, event.data.buffer, player);
     }
     if (event.data.message === 'UPDATE_RECORDING_LENGTH') {
       recordingLength = event.data.recordingLength;
@@ -125,7 +126,8 @@ function handleRecording(processorPort, recordingProperties) {
           Math.round(recordingLength / context.sampleRate * 100)/100;
     }
     if (event.data.message === 'SHARE_RECORDING_BUFFER') {
-      createRecord(recordingProperties, recordingLength, context.sampleRate, downloadLink, downloadButton, event.data.buffer);
+      createRecord(recordingProperties, recordingLength, context.sampleRate,
+        downloadLink, downloadButton, event.data.buffer, player);
     }
   };
 
@@ -302,8 +304,17 @@ function setupRecordingGainVis() {
 /**
  * Creating the downloadable .wav file for the recorded voice and set
  * the download button clickable.
+ * @param {object} recordingProperties Microphone channel count,
+ *     for accurate recording length calculations.
+ * @param {number} recordingLength The current length of recording
+ * @param {number} sampleRate The sample rate of audio content
+ * @param {object} downloadLink The download link for recording file
+ * @param {object} downloadButton The download button in web
+ * @param {number[]} dataBuffer The dataBuffer of recording
+ * @param {object} player The audio player in the web
  */
-function createRecord(recordingProperties, recordingLength, sampleRate, downloadLink, downloadButton, dataBuffer) {
+function createRecord(recordingProperties, recordingLength, sampleRate,
+  downloadLink, downloadButton, dataBuffer, player) {
   const recordingBuffer = context.createBuffer(
       recordingProperties.numberOfChannels,
       recordingLength,

--- a/src/audio-worklet/migration/worklet-recorder/app.js
+++ b/src/audio-worklet/migration/worklet-recorder/app.js
@@ -117,7 +117,7 @@ function handleRecording(processorPort, recordingProperties) {
       recordText.textContent = 'Ready to download 5 mins';
       recordButton.disabled = true;
       createRecord(recordingProperties, recordingLength, context.sampleRate,
-        downloadLink, downloadButton, event.data.buffer, player);
+          downloadLink, downloadButton, event.data.buffer, player);
     }
     if (event.data.message === 'UPDATE_RECORDING_LENGTH') {
       recordingLength = event.data.recordingLength;
@@ -127,7 +127,7 @@ function handleRecording(processorPort, recordingProperties) {
     }
     if (event.data.message === 'SHARE_RECORDING_BUFFER') {
       createRecord(recordingProperties, recordingLength, context.sampleRate,
-        downloadLink, downloadButton, event.data.buffer, player);
+          downloadLink, downloadButton, event.data.buffer, player);
     }
   };
 
@@ -314,7 +314,7 @@ function setupRecordingGainVis() {
  * @param {object} player The audio player in the web
  */
 const createRecord = (recordingProperties, recordingLength, sampleRate,
-  downloadLink, downloadButton, dataBuffer, player) => {
+    downloadLink, downloadButton, dataBuffer, player) => {
   const recordingBuffer = context.createBuffer(
       recordingProperties.numberOfChannels,
       recordingLength,

--- a/src/audio-worklet/migration/worklet-recorder/app.js
+++ b/src/audio-worklet/migration/worklet-recorder/app.js
@@ -40,7 +40,7 @@ async function init() {
   const recordingProperties = {
     numberOfChannels: micSourceNode.channelCount,
     sampleRate: context.sampleRate,
-    maxFrameCount: context.sampleRate*300,
+    maxFrameCount: context.sampleRate * 300,
   };
 
   const recordingNode = await setupRecordingWorkletNode(recordingProperties);
@@ -114,7 +114,7 @@ function handleRecording(processorPort, recordingProperties) {
   const recordingEventCallback = async (event) => {
     if (event.data.message === 'MAX_RECORDING_LENGTH_REACHED') {
       isRecording = false;
-      recordText.innerHTML = 'Ready to download 5 mins';
+      recordText.textContent = 'Ready to download 5 mins';
       recordButton.disabled = true;
       createRecord(recordingProperties, recordingLength, context.sampleRate,
         downloadLink, downloadButton, event.data.buffer, player);
@@ -122,7 +122,7 @@ function handleRecording(processorPort, recordingProperties) {
     if (event.data.message === 'UPDATE_RECORDING_LENGTH') {
       recordingLength = event.data.recordingLength;
 
-      document.querySelector('#data-len').innerHTML =
+      document.querySelector('#data-len').textContent =
           Math.round(recordingLength / context.sampleRate * 100)/100;
     }
     if (event.data.message === 'SHARE_RECORDING_BUFFER') {
@@ -140,7 +140,7 @@ function handleRecording(processorPort, recordingProperties) {
       setRecording: isRecording,
     });
 
-    recordText.innerHTML = isRecording ? 'Stop' : 'Start';
+    recordText.textContent = isRecording ? 'Stop' : 'Start';
     downloadButton.disabled = isRecording ? true : false;
   });
 
@@ -167,7 +167,7 @@ function setupMonitor(monitorNode) {
     // Set gain to quickly but smoothly slide to new value.
     monitorNode.gain.setTargetAtTime(newVal, context.currentTime, 0.01);
 
-    monitorText.innerHTML = isMonitoring ? 'off' : 'on';
+    monitorText.textContent = isMonitoring ? 'off' : 'on';
   });
 }
 
@@ -211,7 +211,7 @@ function setupVisualizers() {
   const visToggle = document.querySelector('#viz-toggle');
   visToggle.addEventListener('click', (e) => {
     visualizationEnabled = !visualizationEnabled;
-    visToggle.querySelector('span').innerHTML =
+    visToggle.querySelector('span').textContent =
       visualizationEnabled ? 'Pause' : 'Play';
   });
 
@@ -313,8 +313,8 @@ function setupRecordingGainVis() {
  * @param {number[]} dataBuffer The dataBuffer of recording
  * @param {object} player The audio player in the web
  */
-function createRecord(recordingProperties, recordingLength, sampleRate,
-  downloadLink, downloadButton, dataBuffer, player) {
+const createRecord = (recordingProperties, recordingLength, sampleRate,
+  downloadLink, downloadButton, dataBuffer, player) => {
   const recordingBuffer = context.createBuffer(
       recordingProperties.numberOfChannels,
       recordingLength,
@@ -324,12 +324,10 @@ function createRecord(recordingProperties, recordingLength, sampleRate,
     recordingBuffer.copyToChannel(dataBuffer[i], i, 0);
   }
 
-  const wavUrl = createLinkFromAudioBuffer(
-      recordingBuffer,
-      true);
+  const recordingUrl = createLinkFromAudioBuffer(recordingBuffer, true);
 
-  player.src = wavUrl;
-  downloadLink.src = wavUrl;
-  downloadLink.download = 'recording.wav';
+  player.src = recordingUrl;
+  downloadLink.src = recordingUrl;
+  downloadLink.download = 'recording-' + new Date().getMilliseconds().toString() + '.wav';
   downloadButton.disabled = false;
 };

--- a/src/audio-worklet/migration/worklet-recorder/index.njk
+++ b/src/audio-worklet/migration/worklet-recorder/index.njk
@@ -23,7 +23,11 @@ to_root_dir: ../../../
 </style>
 
 <h1>AudioWorklet Recorder</h1>
-<p>Demonstrates a simple recording app using Audio Worklet</p>
+<p>Demonstrates a simple recording app using Audio Worklet. The maximum recording time is 5 mins. After reaching the maximum recording time,
+the recording will be paused automatically and perpare a download link as .wav file. Due to the file size and recording length, it might 
+take a while to perpare the downloadble link and preview recording. Please be patient.</p>
+
+<p>If you want to RERUN the example, please refresh this page.</p>
 
 <h3 class="text-2xl text-bold text-green-500" id="click-to-start">Click anywhere to start!</h3>
 
@@ -58,8 +62,8 @@ to_root_dir: ../../../
       <audio id="player" class="w-full" controls></audio>
 
       <div class="my-2">
-        <a href="" id="download">
-          <button>download file</button>
+        <a href="" id="download-link">
+          <button disabled id="download-button">download file</button>
         </a>
       </div>
     </div>

--- a/src/audio-worklet/migration/worklet-recorder/index.njk
+++ b/src/audio-worklet/migration/worklet-recorder/index.njk
@@ -23,9 +23,11 @@ to_root_dir: ../../../
 </style>
 
 <h1>AudioWorklet Recorder</h1>
-<p>Demonstrates a simple recording app using Audio Worklet. The maximum recording time is 5 mins. After reaching the maximum recording time,
-the recording will be paused automatically and perpare a download link as .wav file. Due to the file size and recording length, it might 
-take a while to perpare the downloadble link and preview recording. Please be patient.</p>
+<p>This is a simple recording app that uses the AudioWorklet API. The maximum recording
+time is 5 minutes. After reaching the maximum recording time, the recording will be
+stopped automatically and a download link for the `.wav` file will be prepared. Due
+to the file size and recording length, it may take a few moments to prepare the download
+link and preview the recording. To restart the recording, please click the Refresh button.</p>
 
 <p>If you want to RERUN the example, please refresh this page.</p>
 

--- a/src/audio-worklet/migration/worklet-recorder/index.njk
+++ b/src/audio-worklet/migration/worklet-recorder/index.njk
@@ -23,13 +23,13 @@ to_root_dir: ../../../
 </style>
 
 <h1>AudioWorklet Recorder</h1>
-<p>This is a simple recording app that uses the AudioWorklet API. The maximum recording
-time is 5 minutes. After reaching the maximum recording time, the recording will be
-stopped automatically and a download link for the `.wav` file will be prepared. Due
-to the file size and recording length, it may take a few moments to prepare the download
-link and preview the recording. To restart the recording, please click the Refresh button.</p>
-
-<p>If you want to RERUN the example, please refresh this page.</p>
+<p>This is a simple recording app that uses the AudioWorklet API.
+The maximum recording time is 5 minutes. After reaching the maximum
+recording time, the recording will be stopped automatically and a
+download link for the `.wav` file will be prepared. Due to the file
+size and recording length, it may take a few moments to prepare the
+download link and preview the recording. To restart the recording,
+please click the Refresh button.</p>
 
 <h3 class="text-2xl text-bold text-green-500" id="click-to-start">Click anywhere to start!</h3>
 

--- a/src/audio-worklet/migration/worklet-recorder/recording-processor.js
+++ b/src/audio-worklet/migration/worklet-recorder/recording-processor.js
@@ -89,6 +89,13 @@ class RecordingProcessor extends AudioWorkletProcessor {
         this.isRecording = false;
         this.port.postMessage({
           message: 'MAX_RECORDING_LENGTH_REACHED',
+          buffer: this._recordingBuffer,
+        });
+
+        this.recordedFrames += 128;
+        this.port.postMessage({
+          message: 'UPDATE_RECORDING_LENGTH',
+          recordingLength: this.recordedFrames,
         });
 
         return false;


### PR DESCRIPTION
#294 issue solution.
The  AudioWorklet Recorder demo is not able to preview and download the recording when the record time reach the maximum limit. I also extend the max recording time to 5 mins and provide better user experience of using this demo. 