### PR TITLE
Centering the 'Web Audio/MIDI Samples' 

### DIFF
--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -2,6 +2,7 @@
 
 h1 {
   @apply text-5xl pb-6;
+  text-align: center
 }
 
 h2 {


### PR DESCRIPTION
Centering the heading 'Web Audio/MIDI Samples' using the 'text-align: center' property.