### PR TITLE
Add a manual test for setSinkId

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -73,6 +73,8 @@ module.exports = function(eleventyConfig) {
     'src/sounds/hyper-reality/**/*.wav',
     'src/sounds/impulse-responses/**/*.wav',
     'src/sounds/loops/**/*.wav',
+    'src/tests/**/*.html',
+    'src/tests/**/*.js',
     'src/robots.txt',
     'src/README.md',
     'src/sitemap.xml',

--- a/src/_data/build_info.json
+++ b/src/_data/build_info.json
@@ -1,1 +1,1 @@
-{"version":"3.1.0","revision":"b55ddb9","lastUpdated":"2023-07-05","copyrightYear":2023}
+{"version":"3.1.0","revision":"031cffa","lastUpdated":"2023-07-05","copyrightYear":2023}

--- a/src/_data/tests_data.yaml
+++ b/src/_data/tests_data.yaml
@@ -1,0 +1,5 @@
+- title: Tests
+  entries:
+    - title: AudioContext.setSinkId()
+      description: A manual test for setSinkId() API
+      href: setsinkid/

--- a/src/tests/index.njk
+++ b/src/tests/index.njk
@@ -1,0 +1,36 @@
+---
+eleventyNavigation:
+  key: tests
+  title: Various tests for Web Audio API
+  parent: landing
+to_root_dir: ../
+---
+
+{% extends "../_includes/base.njk" %}
+
+{% block content %}
+
+<div class="mb-12">
+  <h1>Tests</h1>
+  <p>TODO: Various tests for Chrome Web Audio API</p>
+</div>
+
+{% for section in tests_data %}
+<div class="my-6">
+  <h2 class="text-3xl pb-6">
+    {{ section.title }}
+  </h2>
+  <div class="flex flex-wrap">
+    {% for entry in section.entries %}
+      <div class="w-full md:w-1/2 pb-6">
+        <a href="{{ entry.href }}" class="text-xl">
+          {{ entry.title }}
+        </a>
+        <p>{{ entry.description }}</p>
+      </div>
+    {% endfor %}
+  </div>
+</div>
+{% endfor %}
+
+{% endblock %}

--- a/src/tests/setsinkid/app.js
+++ b/src/tests/setsinkid/app.js
@@ -1,0 +1,95 @@
+// Copyright (c) 2023 The Chromium Authors. All rights reserved.  Use
+// of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+'use strict';
+
+const sanitizeSinkId = (sinkId) => {
+  if (typeof sinkId === 'object' && sinkId.type === 'none')
+    return `[silent sink]`;
+
+  if (sinkId === '') return '[default]';
+
+  return sinkId.substring(0, 8);
+}
+
+// Handles the button click to activate `setSinkId()` method.
+const onDeviceChange = async (event, audioContext, appView) => {
+  const deviceId = appView.dropdown.value;
+  if (deviceId === 'default') {
+    await audioContext.setSinkId('');
+  } else if (deviceId === 'silent') {
+    await audioContext.setSinkId({type: 'none'});
+  } else {
+    await audioContext.setSinkId(deviceId);
+  }
+
+  appView.inspector.textContent =
+      `AudioContext.sinkId = ${sanitizeSinkId(audioContext.sinkId)}
+      (${audioContext.destination.maxChannelCount} channels max)`;
+};
+
+// The manual test body
+const startManualTest = async () => {
+  const appView = {
+    log: document.getElementById('log'),
+    inspector: document.getElementById('inspector'),
+    dropdown: document.getElementById('device-dropdown'),
+    changeButton: document.getElementById('device-change')
+  };
+
+  const audioContext = new AudioContext();
+  const osc = new OscillatorNode(audioContext, {type: 'sawtooth'});
+  const amp = new GainNode(audioContext, {gain: 0.015});
+  osc.connect(amp).connect(audioContext.destination);
+  osc.start();
+
+  if (typeof audioContext.setSinkId !== 'function' ||
+      typeof audioContext.sinkId != 'string') {
+    appView.log.textContent =
+        'This browser does not support AudioContext.setSinkId()';
+    return;
+  }
+
+  appView.inspector.textContent =
+      `AudioContext.sinkId = ${sanitizeSinkId(audioContext.sinkId)}
+      (${audioContext.destination.maxChannelCount} channels max)`;
+
+  // Get a permission, enumerate devices, and set up the UI.
+  try {
+    const stream =
+        await navigator.mediaDevices.getUserMedia({ audio: true });
+    if (stream) {
+      const deviceList = await navigator.mediaDevices.enumerateDevices();
+      let deviceListString = '';
+      deviceList.forEach((device) => {
+        if (device.kind === 'audiooutput') {
+          deviceListString +=
+              `<option value="${device.deviceId}">${device.label}</option>`;
+        }
+      });
+      deviceListString +=
+          `<option value="silent">none (silent output)</option>`;
+      appView.dropdown.innerHTML = deviceListString;
+      appView.changeButton.addEventListener('click', (event) => {
+        audioContext.resume();
+        onDeviceChange(event, audioContext, appView);
+      });
+      appView.dropdown.disabled = false;
+      appView.changeButton.disabled = false;
+      appView.log.textContent =
+          'Retrieved device information successfully. Ready to test.';
+    } else {
+      appView.log.textContent =
+          'navigator.mediaDevices.getUserMedia() failed.';
+    }
+  } catch (error) {
+    // The permission dialog was dismissed, or acquiring a stream from
+    // getUserMedia() failed.
+    console.error(error);
+    appView.log.textContent = `The initialization failed: ${error}`;
+  }
+};
+
+// Entry point
+window.addEventListener('load', startManualTest);

--- a/src/tests/setsinkid/index.njk
+++ b/src/tests/setsinkid/index.njk
@@ -1,0 +1,36 @@
+---
+eleventyNavigation:
+  key: test-setsinkid
+  title: Manual test for AudioContext.setSinkId()
+  parent: tests
+to_root_dir: ../../
+---
+
+{% extends "../../_includes/base.njk" %}
+
+{% block content %}
+
+<h1>AudioContext.setSinkId(): Manual Test</h1>
+<p>NOTE: This test requires a permission for microphone to access the available
+  audio devices in the system.</p>
+
+<div class="demo-box">
+  <div class="p-3 mb-2 bg-slate-100 w-1/2 rounded text-sm text-right">
+    <label for="type" class="mr-1 w-1/3">Output Device</label>
+    <select id="device-dropdown" disabled
+      class="p-1 rounded w-2/3 font-semibold">
+      <option value="">Getting device information...</option>
+    </select>
+  </div>
+  <button id="device-change" disabled>CHANGE</button>
+</div>
+
+<div id="view"
+  class="mt-6 p-3 rounded text-xs text-slate-600 border font-mono">
+  <div id="log"></div>
+  <div id="inspector"></div>
+</div>
+
+<script type="module" src="app.js"></script>
+
+{% endblock %}


### PR DESCRIPTION
This PR adds a manual test for Chrome's AudioContext.setSinkId() method. This way, this test can always be online and ready to run for a new Chromium build.

This is a companion PR of https://crrev.com/c/4670272.

