### PR TITLE
Adding a manual test for PannerNode

### DIFF
--- a/src/_data/build_info.json
+++ b/src/_data/build_info.json
@@ -1,1 +1,1 @@
-{"version":"3.1.0","revision":"031cffa","lastUpdated":"2023-07-05","copyrightYear":2023}
+{"version":"3.1.0","revision":"fce9086","lastUpdated":"2023-07-10","copyrightYear":2023}

--- a/src/_data/tests_data.yaml
+++ b/src/_data/tests_data.yaml
@@ -3,3 +3,6 @@
     - title: AudioContext.setSinkId()
       description: A manual test for setSinkId() API
       href: setsinkid/
+    - title: Performance of PannerNode and AudioListener
+      description: Manual test for performance of PannerNode and AudioListener
+      href: pannernode/

--- a/src/tests/pannernode/app.js
+++ b/src/tests/pannernode/app.js
@@ -1,0 +1,84 @@
+const Test = { 
+  initialized: false
+};
+
+const logMessage = (message, delayInSecond = 0) => {
+  console.assert(Test.log);
+
+  setTimeout(() => {
+    Test.log.textContent +=
+        '[' + performance.now().toFixed(2) + '] ' + message + '\r\n';
+  }, delayInSecond * 1000);
+};
+
+const startAudio = async () => {
+  console.assert(Test.initialized);
+
+  Test.startAudioButton.disabled = true;
+  logMessage('Test started.');
+
+  const audioContext = new AudioContext();
+  const source = new ConstantSourceNode(audioContext, {offset: 0.5});
+  // Intentionally using a low gain value so we ensure there's no clipping.
+  const gain = new GainNode(audioContext, {gain: 0.25});
+  const panner = new PannerNode(audioContext, {panningModel: 'HRTF'});
+
+  source.connect(gain).connect(panner).connect(audioContext.destination);
+  source.start();
+
+  // Each sub test runs for 3 seconds.
+  const testDuration = 3.0;
+
+  // This is to avoid a sudden position change while panning. Values that are
+  // lower than this will cause a sudden change for all axis.
+  const nonZero = 0.1;
+
+  // For the details on spatialization, see:
+  // https://webaudio.github.io/web-audio-api/#Spatialization
+
+  // X-axis: from left (-1) to right (1)
+  let now = audioContext.currentTime;
+  let later = now + testDuration;
+  panner.positionX.setValueAtTime(-1.0, now);
+  panner.positionY.setValueAtTime(nonZero, now);
+  panner.positionZ.setValueAtTime(nonZero, now);
+  panner.positionX.linearRampToValueAtTime(1.0, later);
+  logMessage('Test X-axis: From left to right over 3 seconds.');
+
+  // Y-axis: from bottom (-1) to top (1)
+  now += testDuration;
+  later = now + 3.0;
+  panner.positionX.setValueAtTime(nonZero, now);
+  panner.positionY.setValueAtTime(-1.0, now);
+  panner.positionZ.setValueAtTime(nonZero, now);
+  panner.positionY.linearRampToValueAtTime(1.0, later);
+  logMessage('Test Y-axis: From top to bottom over 3 seconds.', testDuration);
+
+  // Z-axis: from front (-1) to back (1)
+  now += testDuration;
+  later = now + 3.0;
+  panner.positionX.setValueAtTime(nonZero, now);
+  panner.positionY.setValueAtTime(nonZero, now);
+  panner.positionZ.setValueAtTime(-1.0, now);
+  panner.positionZ.linearRampToValueAtTime(1.0, later);
+  logMessage('Test Z-axis: From front to back over 3 seconds.',
+             2 * testDuration);
+
+  source.stop(later);
+  logMessage('Test finished.', 3 * testDuration);
+};
+
+const initializeTest = async () => {
+  Test.log = document.getElementById('log');
+  Test.inspector = document.getElementById('inspector');
+  Test.startAudioButton = document.getElementById('btn-start-test');
+
+  Test.startAudioButton.onclick = startAudio;
+  Test.startAudioButton.disabled = false;
+
+  logMessage('Test initialized. Press "Start Audio" to begin.');
+  Test.initialized = true;
+};
+
+// Entry point
+window.addEventListener('load', initializeTest);

--- a/src/tests/pannernode/index.njk
+++ b/src/tests/pannernode/index.njk
@@ -1,0 +1,41 @@
+---
+eleventyNavigation:
+  key: test-pannernode
+  title: Glitches in PannerNode
+  parent: tests
+to_root_dir: ../../
+---
+
+{% extends "../../_includes/base.njk" %}
+
+{% block content %}
+
+<h1>{{ eleventyNavigation.title }}</h1>
+<p>Press "Start Audio" button to start the test. The test will play 3 segments
+  (3 seconds each) of the ConstantSourceNode with a DC offset of 0.5. This
+  source is spatialized by the PannerNode with HRTF. Ideally, the spatialization
+  should not cause any artifacts. (e.g. glitches, sudden changes)</p>
+<ul class="pl-3 mb-3 list-inside list-disc">
+  <li>
+    <a href="https://webaudio.github.io/web-audio-api/#Spatialization"
+      target=_blank>
+      Specification: Spatialization</a>
+    <a href=""></a>
+  </li>
+</ul>
+<p>Refresh the page to run the test again.</p>
+
+<div class="demo-box">
+  <button id="btn-start-test" disabled>START TEST</button>
+  {% include "../../_includes/example-source-code.njk" %}
+</div>
+
+<div id="view"
+  class="mt-6 p-3 rounded border">
+  <div id="log" class="text-xs text-slate-600 font-mono whitespace-pre"></div>
+  <div id="inspector"></div>
+</div>
+
+<script type="module" src="app.js"></script>
+
+{% endblock %}


### PR DESCRIPTION
This PR adds a manual test for PannerNode, which can be useful when the team verify the PannerNode improvement on issues (e.g. GC, processing artifacts) in the future.

![Screenshot 2023-07-10 at 11 22 42 AM](https://github.com/GoogleChromeLabs/web-audio-samples/assets/676891/43477604-2700-41dc-b310-3ec3b686b42a)
