### PR TITLE
Fix Emscripten runtime failure

### DIFF
--- a/src/_data/build_info.json
+++ b/src/_data/build_info.json
@@ -1,1 +1,1 @@
-{"version":"3.1.0","revision":"6b3e732","lastUpdated":"2023-10-13","copyrightYear":2023}
+{"version":"3.1.0","revision":"7201485","lastUpdated":"2023-11-02","copyrightYear":2023}

--- a/src/_data/build_info.json
+++ b/src/_data/build_info.json
@@ -1,1 +1,1 @@
-{"version":"3.1.0","revision":"fce9086","lastUpdated":"2023-07-10","copyrightYear":2023}
+{"version":"3.1.0","revision":"6b3e732","lastUpdated":"2023-10-13","copyrightYear":2023}

--- a/src/audio-worklet/design-pattern/wasm-supersaw/Makefile
+++ b/src/audio-worklet/design-pattern/wasm-supersaw/Makefile
@@ -24,6 +24,7 @@ build: $(DEPS)
 		-s SINGLE_FILE=1 \
 		-s WASM=1 \
 		-s WASM_ASYNC_COMPILATION=0 \
+		-s EXPORTED_FUNCTIONS="['_malloc']" \
 		-o ./synth.wasm.js \
 		./synth_src/synth_bind.cc $(DEPS)
 

--- a/src/audio-worklet/design-pattern/wasm-supersaw/README.md
+++ b/src/audio-worklet/design-pattern/wasm-supersaw/README.md
@@ -4,8 +4,13 @@ Unlike other AudioWorklet examples in this repository, this examples needs
 an additional step to build and compile. Follow the steps below:
 
 1. Install Emscripten in your development setup. Follow the instruction:
-    https://emscripten.org/docs/getting_started/downloads.html
+  https://emscripten.org/docs/getting_started/downloads.html
 
-2. Run `emcc -v` to confirm the Emscripten installation and its version.
+2. Run `emcc -v` to confirm the Emscripten installation and its version. This
+  example needs 3.1.48 or later to work correctly. (See
+  [this issue](https://github.com/GoogleChromeLabs/web-audio-samples/issues/348)
+  for details)
 
-3. 
+3. In the terminal, run `make` to build the WASM file.
+
+4. Serve `index.html` file in the directoy.

--- a/src/audio-worklet/design-pattern/wasm-supersaw/README.md
+++ b/src/audio-worklet/design-pattern/wasm-supersaw/README.md
@@ -1,0 +1,11 @@
+# How to use wasm-supersaw example
+
+Unlike other AudioWorklet examples in this repository, this examples needs
+an additional step to build and compile. Follow the steps below:
+
+1. Install Emscripten in your development setup. Follow the instruction:
+    https://emscripten.org/docs/getting_started/downloads.html
+
+2. Run `emcc -v` to confirm the Emscripten installation and its version.
+
+3. 


### PR DESCRIPTION
Fixes #348.

The latest stable of Emscripten 3.1.47 caused some runtime errors in the WASM SuperSaw example, and this PR fixes the problem. The details can be found here: https://github.com/GoogleChromeLabs/web-audio-samples/issues/348#issuecomment-1791272814
