### PR TITLE
Mean absolute value of [-1,+1] samples for visualizers

### DIFF
--- a/src/audio-worklet/migration/worklet-recorder/recording-processor.js
+++ b/src/audio-worklet/migration/worklet-recorder/recording-processor.js
@@ -67,7 +67,8 @@ class RecordingProcessor extends AudioWorkletProcessor {
           outputs[input][channel][sample] = currentSample;
 
           // Sum values for visualizer
-          this.sampleSum += Math.abs(currentSample);        }
+          this.sampleSum += Math.abs(currentSample);
+        }
       }
     }
 


### PR DESCRIPTION
The visualizer vaveform averages of float samples in [-1, 1] look terrible, because their absolute value was not used in computing the mean. ~~You might also consider sending the cube root of these means, because the typical value is so small. I.e.,~~ [EDIT: there's a much better adjustment in my comment below.]

```
gain: this.visualSign * Math.pow(this.sampleSum / this.framesSinceLastPublish, 0.333),
```

``this.visualSign`` is used to show each agregate with alternating signs so the visualization looks like an actual sound pressure wave instead of just the top half of one.