### PR TITLE
Fix: Implemented STOP button behavior to toggle audio playback

### DIFF
--- a/src/_data/build_info.json
+++ b/src/_data/build_info.json
@@ -1,1 +1,1 @@
-{"version":"3.1.0","revision":"bf3ea58","lastUpdated":"2024-03-08","copyrightYear":2024}
+{"version":"3.1.0","revision":"894b234","lastUpdated":"2024-03-14","copyrightYear":2024}

--- a/src/_data/build_info.json
+++ b/src/_data/build_info.json
@@ -1,1 +1,1 @@
-{"version":"3.1.0","revision":"894b234","lastUpdated":"2024-03-14","copyrightYear":2024}
+{"version":"3.1.0","revision":"2df8734","lastUpdated":"2024-03-26","copyrightYear":2024}

--- a/src/_data/build_info.json
+++ b/src/_data/build_info.json
@@ -1,1 +1,1 @@
-{"version":"3.1.0","revision":"0643084","lastUpdated":"2024-03-07","copyrightYear":2024}
+{"version":"3.1.0","revision":"bf3ea58","lastUpdated":"2024-03-08","copyrightYear":2024}

--- a/src/_data/build_info.json
+++ b/src/_data/build_info.json
@@ -1,1 +1,1 @@
-{"version":"3.1.0","revision":"7201485","lastUpdated":"2023-11-02","copyrightYear":2023}
+{"version":"3.1.0","revision":"0643084","lastUpdated":"2024-03-07","copyrightYear":2024}

--- a/src/audio-worklet/basic/audio-worklet-node-options/index.njk
+++ b/src/audio-worklet/basic/audio-worklet-node-options/index.njk
@@ -35,7 +35,7 @@ to_root_dir: ../../../
     <input type="number" name="frequency" id="demo-input-frequency"
       class="p-1 rounded w-1/2 font-semibold" min="1" max="20000" value=440>
   </div>
-  <button id="button-start" disabled>START</button>
+  <button id="button-start" class="start-button">START</button>
   {% include "../../../_includes/example-source-code.njk" %}
 </div>
 

--- a/src/audio-worklet/basic/audio-worklet-node-options/main.js
+++ b/src/audio-worklet/basic/audio-worklet-node-options/main.js
@@ -6,21 +6,16 @@ const audioContext = new AudioContext();
 let oscillatorProcessor;
 
 const startAudio = async (context, options) => {
-  await context.audioWorklet.addModule('oscillator-processor.js');
-  oscillatorProcessor =
-    new AudioWorkletNode(context, 'oscillator-processor', {
-      processorOptions: {
-        waveformType: options.waveformType,
-        frequency: options.frequency,
-      }
-    });
-  oscillatorProcessor.connect(context.destination);
-};
-
-const stopAudio = () => {
-  if (oscillatorProcessor) {
-    oscillatorProcessor.disconnect();
-    oscillatorProcessor = null;
+  if (!oscillatorProcessor) {
+    await context.audioWorklet.addModule('oscillator-processor.js');
+    oscillatorProcessor =
+      new AudioWorkletNode(context, 'oscillator-processor', {
+        processorOptions: {
+          waveformType: options.waveformType,
+          frequency: options.frequency,
+        }
+      });
+    oscillatorProcessor.connect(context.destination);
   }
 };
 
@@ -32,14 +27,14 @@ window.addEventListener('load', async () => {
 
   buttonEl.addEventListener('click', async () => {
     if (!oscillatorProcessor) { // If audio is not playing, start audio
-      const waveformType =
-        document.querySelector('#demo-select-waveform-type').value;
+      const waveformType = document.querySelector('#demo-select-waveform-type').value;
       const frequency = document.querySelector('#demo-input-frequency').value;
       await startAudio(audioContext, { waveformType, frequency });
       audioContext.resume();
       buttonEl.textContent = 'STOP';
     } else { // If audio is playing, stop audio
-      stopAudio();
+      oscillatorProcessor.disconnect();
+      oscillatorProcessor = null;
       buttonEl.textContent = 'START';
     }
   }, false);

--- a/src/audio-worklet/basic/audio-worklet-node-options/main.js
+++ b/src/audio-worklet/basic/audio-worklet-node-options/main.js
@@ -6,17 +6,15 @@ const audioContext = new AudioContext();
 let oscillatorProcessor;
 
 const startAudio = async (context, options) => {
-  if (!oscillatorProcessor) {
-    await context.audioWorklet.addModule('oscillator-processor.js');
-    oscillatorProcessor =
-      new AudioWorkletNode(context, 'oscillator-processor', {
-        processorOptions: {
-          waveformType: options.waveformType,
-          frequency: options.frequency,
-        }
-      });
-    oscillatorProcessor.connect(context.destination);
-  }
+  await context.audioWorklet.addModule('oscillator-processor.js');
+  oscillatorProcessor =
+    new AudioWorkletNode(context, 'oscillator-processor', {
+      processorOptions: {
+        waveformType: options.waveformType,
+        frequency: options.frequency,
+      }
+    });
+  oscillatorProcessor.connect(context.destination);
 };
 
 // A simple onLoad handler. It also handles user gesture to unlock the audio
@@ -26,15 +24,16 @@ window.addEventListener('load', async () => {
   buttonEl.disabled = false;
 
   buttonEl.addEventListener('click', async () => {
-    if (!oscillatorProcessor) { // If audio is not playing, start audio
+    if (!oscillatorProcessor) {
+      // If audio is not playing, start the audio.
       const waveformType = document.querySelector('#demo-select-waveform-type').value;
       const frequency = document.querySelector('#demo-input-frequency').value;
       await startAudio(audioContext, { waveformType, frequency });
       audioContext.resume();
       buttonEl.textContent = 'STOP';
-    } else { // If audio is playing, stop audio
-      oscillatorProcessor.disconnect();
-      oscillatorProcessor = null;
+    } else {
+      // If audio is playing, stop the audio.
+      audioContext.suspend();
       buttonEl.textContent = 'START';
     }
   }, false);

--- a/src/audio-worklet/basic/audio-worklet-node-options/main.js
+++ b/src/audio-worklet/basic/audio-worklet-node-options/main.js
@@ -3,30 +3,44 @@
 // found in the LICENSE file.
 
 const audioContext = new AudioContext();
+let oscillatorProcessor;
 
 const startAudio = async (context, options) => {
   await context.audioWorklet.addModule('oscillator-processor.js');
-  const oscillatorProcessor =
-      new AudioWorkletNode(context, 'oscillator-processor', {
-        processorOptions: {
-          waveformType: options.waveformType,
-          frequency: options.frequency,
-        }});
+  oscillatorProcessor =
+    new AudioWorkletNode(context, 'oscillator-processor', {
+      processorOptions: {
+        waveformType: options.waveformType,
+        frequency: options.frequency,
+      }
+    });
   oscillatorProcessor.connect(context.destination);
 };
 
-// A simplem onLoad handler. It also handles user gesture to unlock the audio
+const stopAudio = () => {
+  if (oscillatorProcessor) {
+    oscillatorProcessor.disconnect();
+    oscillatorProcessor = null;
+  }
+};
+
+// A simple onLoad handler. It also handles user gesture to unlock the audio
 // playback.
 window.addEventListener('load', async () => {
   const buttonEl = document.getElementById('button-start');
   buttonEl.disabled = false;
+
   buttonEl.addEventListener('click', async () => {
-    const waveformType =
+    if (!oscillatorProcessor) { // If audio is not playing, start audio
+      const waveformType =
         document.querySelector('#demo-select-waveform-type').value;
-    const frequency = document.querySelector('#demo-input-frequency').value;
-    await startAudio(audioContext, {waveformType, frequency});
-    audioContext.resume();
-    buttonEl.disabled = true;
-    buttonEl.textContent = 'Playing...';
+      const frequency = document.querySelector('#demo-input-frequency').value;
+      await startAudio(audioContext, { waveformType, frequency });
+      audioContext.resume();
+      buttonEl.textContent = 'STOP';
+    } else { // If audio is playing, stop audio
+      stopAudio();
+      buttonEl.textContent = 'START';
+    }
   }, false);
 });

--- a/src/audio-worklet/basic/hello-audio-worklet/index.njk
+++ b/src/audio-worklet/basic/hello-audio-worklet/index.njk
@@ -18,7 +18,7 @@ to_root_dir: ../../../
   Chrome Developers Article: Enter Audio Worklet</a> for more information.</p>
 
 <div class="demo-box">
-  <button id="button-start" disabled>START</button>
+  <button id="button-start" class="start-button">START</button>
   {% include "../../../_includes/example-source-code.njk" %}
 </div>
 

--- a/src/audio-worklet/basic/hello-audio-worklet/main.js
+++ b/src/audio-worklet/basic/hello-audio-worklet/main.js
@@ -3,13 +3,22 @@
 // found in the LICENSE file.
 
 const audioContext = new AudioContext();
+let oscillator; 
+let isPlaying = false; 
 
 const startAudio = async (context) => {
   await context.audioWorklet.addModule('bypass-processor.js');
-  const oscillator = new OscillatorNode(context);
+  oscillator = new OscillatorNode(context);
   const bypasser = new AudioWorkletNode(context, 'bypass-processor');
   oscillator.connect(bypasser).connect(context.destination);
   oscillator.start();
+};
+
+const stopAudio = () => {
+  if (oscillator) {
+    oscillator.stop();
+    oscillator.disconnect();
+  }
 };
 
 // A simplem onLoad handler. It also handles user gesture to unlock the audio
@@ -17,10 +26,31 @@ const startAudio = async (context) => {
 window.addEventListener('load', async () => {
   const buttonEl = document.getElementById('button-start');
   buttonEl.disabled = false;
+
   buttonEl.addEventListener('click', async () => {
-    await startAudio(audioContext);
-    audioContext.resume();
-    buttonEl.disabled = true;
-    buttonEl.textContent = 'Playing...';
-  }, false);
+    if (!isPlaying) { 
+      await startAudio(audioContext);
+      audioContext.resume();
+      isPlaying = true;
+      buttonEl.textContent = 'Playing...'; 
+      buttonEl.classList.remove('start-button');
+    } else { 
+      stopAudio();
+      isPlaying = false;
+      buttonEl.textContent = 'START';
+      buttonEl.classList.add('start-button'); 
+    }
+  });
+
+  buttonEl.addEventListener('mouseenter', () => {
+    if (isPlaying) { 
+      buttonEl.textContent = 'STOP';
+    }
+  });
+
+  buttonEl.addEventListener('mouseleave', () => {
+    if (isPlaying) { 
+      buttonEl.textContent = 'Playing...';
+    }
+  });
 });

--- a/src/audio-worklet/basic/hello-audio-worklet/main.js
+++ b/src/audio-worklet/basic/hello-audio-worklet/main.js
@@ -3,21 +3,22 @@
 // found in the LICENSE file.
 
 const audioContext = new AudioContext();
-let oscillator; 
+let oscillatorNode; 
 let isPlaying = false; 
 
 const startAudio = async (context) => {
-  await context.audioWorklet.addModule('bypass-processor.js');
-  oscillator = new OscillatorNode(context);
-  const bypasser = new AudioWorkletNode(context, 'bypass-processor');
-  oscillator.connect(bypasser).connect(context.destination);
-  oscillator.start();
+  if (!oscillatorNode) {
+    await context.audioWorklet.addModule('bypass-processor.js');
+    oscillatorNode = new OscillatorNode(context);
+    const bypasser = new AudioWorkletNode(context, 'bypass-processor');
+    oscillatorNode.connect(bypasser).connect(context.destination);
+    oscillatorNode.start();
+  }
 };
 
 const stopAudio = () => {
-  if (oscillator) {
-    oscillator.stop();
-    oscillator.disconnect();
+  if (audioContext.state === 'running') {
+    audioContext.suspend();
   }
 };
 

--- a/src/audio-worklet/basic/hello-audio-worklet/main.js
+++ b/src/audio-worklet/basic/hello-audio-worklet/main.js
@@ -23,12 +23,17 @@ window.addEventListener('load', async () => {
   buttonEl.addEventListener('click', async () => {
     if (!oscillatorNode) {
       await startAudio(audioContext);
-      audioContext.resume();
+      await audioContext.resume();
+      isPlaying = true;
+      buttonEl.textContent = 'Playing...';
+      buttonEl.classList.remove('start-button');
+    } else if (audioContext.state === 'suspended') {
+      await audioContext.resume();
       isPlaying = true;
       buttonEl.textContent = 'Playing...';
       buttonEl.classList.remove('start-button');
     } else {
-      audioContext.suspend();
+      await audioContext.suspend();
       isPlaying = false;
       buttonEl.textContent = 'START';
       buttonEl.classList.add('start-button');

--- a/src/audio-worklet/basic/hello-audio-worklet/main.js
+++ b/src/audio-worklet/basic/hello-audio-worklet/main.js
@@ -3,23 +3,15 @@
 // found in the LICENSE file.
 
 const audioContext = new AudioContext();
-let oscillatorNode; 
-let isPlaying = false; 
+let oscillatorNode;
+let isPlaying = false;
 
 const startAudio = async (context) => {
-  if (!oscillatorNode) {
-    await context.audioWorklet.addModule('bypass-processor.js');
-    oscillatorNode = new OscillatorNode(context);
-    const bypasser = new AudioWorkletNode(context, 'bypass-processor');
-    oscillatorNode.connect(bypasser).connect(context.destination);
-    oscillatorNode.start();
-  }
-};
-
-const stopAudio = () => {
-  if (audioContext.state === 'running') {
-    audioContext.suspend();
-  }
+  await context.audioWorklet.addModule('bypass-processor.js');
+  oscillatorNode = new OscillatorNode(context);
+  const bypasser = new AudioWorkletNode(context, 'bypass-processor');
+  oscillatorNode.connect(bypasser).connect(context.destination);
+  oscillatorNode.start();
 };
 
 // A simplem onLoad handler. It also handles user gesture to unlock the audio
@@ -29,28 +21,28 @@ window.addEventListener('load', async () => {
   buttonEl.disabled = false;
 
   buttonEl.addEventListener('click', async () => {
-    if (!isPlaying) { 
+    if (!oscillatorNode) {
       await startAudio(audioContext);
       audioContext.resume();
       isPlaying = true;
-      buttonEl.textContent = 'Playing...'; 
+      buttonEl.textContent = 'Playing...';
       buttonEl.classList.remove('start-button');
-    } else { 
-      stopAudio();
+    } else {
+      audioContext.suspend();
       isPlaying = false;
       buttonEl.textContent = 'START';
-      buttonEl.classList.add('start-button'); 
+      buttonEl.classList.add('start-button');
     }
   });
 
   buttonEl.addEventListener('mouseenter', () => {
-    if (isPlaying) { 
+    if (isPlaying) {
       buttonEl.textContent = 'STOP';
     }
   });
 
   buttonEl.addEventListener('mouseleave', () => {
-    if (isPlaying) { 
+    if (isPlaying) {
       buttonEl.textContent = 'Playing...';
     }
   });

--- a/src/audio-worklet/basic/noise-generator/index.njk
+++ b/src/audio-worklet/basic/noise-generator/index.njk
@@ -19,7 +19,7 @@ to_root_dir: ../../../
   Chrome Developers Article: Enter Audio Worklet</a> for more information.</p>
 
 <div class="demo-box">
-  <button id="button-start" disabled>START</button>
+  <button id="button-start" class="start-button">START</button>
   {% include "../../../_includes/example-source-code.njk" %}
 </div>
 

--- a/src/audio-worklet/basic/noise-generator/main.js
+++ b/src/audio-worklet/basic/noise-generator/main.js
@@ -36,7 +36,8 @@ window.addEventListener('load', async () => {
   buttonEl.disabled = false;
 
   buttonEl.addEventListener('click', async () => {
-    if (!isPlaying) { // If not playing, start audio
+    if (!isPlaying) { 
+      // If not playing, start the audio.
       await startAudio(audioContext);
       audioContext.resume();
       isPlaying = true;

--- a/src/audio-worklet/basic/noise-generator/main.js
+++ b/src/audio-worklet/basic/noise-generator/main.js
@@ -5,9 +5,15 @@
 const audioContext = new AudioContext();
 let isPlaying = false;
 let noiseGenerator;
+let moduleAdded = false;
 
 const startAudio = async (context) => {
-  await context.audioWorklet.addModule('noise-generator.js');
+
+  if(!moduleAdded) {
+    await context.audioWorklet.addModule('noise-generator.js');
+    moduleAdded = true;
+  }
+  
   const modulator = new OscillatorNode(context);
   const modGain = new GainNode(context);
   noiseGenerator = new AudioWorkletNode(context, 'noise-generator');
@@ -39,7 +45,7 @@ window.addEventListener('load', async () => {
     if (!isPlaying) { 
       // If not playing, start the audio.
       await startAudio(audioContext);
-      audioContext.resume();
+      await audioContext.resume();
       isPlaying = true;
       buttonEl.textContent = 'Playing...';
     } else { // If playing, stop audio

--- a/src/audio-worklet/basic/one-pole-filter/index.njk
+++ b/src/audio-worklet/basic/one-pole-filter/index.njk
@@ -19,7 +19,7 @@ to_root_dir: ../../../
   Chrome Developers Article: Enter Audio Worklet</a> for more information.</p>
 
 <div class="demo-box">
-  <button id="button-start" disabled>START</button>
+  <button id="button-start" class="start-button">START</button>
   {% include "../../../_includes/example-source-code.njk" %}
 </div>
 

--- a/src/audio-worklet/basic/one-pole-filter/main.js
+++ b/src/audio-worklet/basic/one-pole-filter/main.js
@@ -3,10 +3,12 @@
 // found in the LICENSE file.
 
 const audioContext = new AudioContext();
+let oscillator; 
+let isPlaying = false; 
 
 const startAudio = async (context) => {
   await context.audioWorklet.addModule('one-pole-processor.js');
-  const oscillator = new OscillatorNode(context);
+  oscillator = new OscillatorNode(context);
   const filter = new AudioWorkletNode(context, 'one-pole-processor');
   const frequencyParam = filter.parameters.get('frequency');
 
@@ -19,15 +21,45 @@ const startAudio = async (context) => {
       .exponentialRampToValueAtTime(0.01, 8.0);
 };
 
+const stopAudio = () => {
+  if (oscillator) {
+    oscillator.stop();
+    oscillator.disconnect();
+  }
+};
+
+
 // A simplem onLoad handler. It also handles user gesture to unlock the audio
 // playback.
 window.addEventListener('load', async () => {
   const buttonEl = document.getElementById('button-start');
   buttonEl.disabled = false;
+
   buttonEl.addEventListener('click', async () => {
-    await startAudio(audioContext);
-    audioContext.resume();
-    buttonEl.disabled = true;
-    buttonEl.textContent = 'Playing...';
-  }, false);
+    if (!isPlaying) { 
+      await startAudio(audioContext);
+      audioContext.resume();
+      isPlaying = true;
+      buttonEl.textContent = 'Playing...'; 
+      buttonEl.classList.remove('start-button');
+    } else { 
+      stopAudio();
+      isPlaying = false;
+      buttonEl.textContent = 'START';
+      buttonEl.classList.add('start-button'); 
+    }
+  });
+
+  buttonEl.addEventListener('mouseenter', () => {
+    if (isPlaying) { 
+      buttonEl.textContent = 'STOP';
+    }
+  });
+
+  buttonEl.addEventListener('mouseleave', () => {
+    if (isPlaying) { 
+      buttonEl.textContent = 'Playing...';
+    }
+  });
 });
+

--- a/src/audio-worklet/basic/one-pole-filter/main.js
+++ b/src/audio-worklet/basic/one-pole-filter/main.js
@@ -5,9 +5,15 @@
 const audioContext = new AudioContext();
 let oscillator; 
 let isPlaying = false; 
+let moduleAdded = false;
 
 const startAudio = async (context) => {
-  await context.audioWorklet.addModule('one-pole-processor.js');
+
+  if(!moduleAdded) {
+    await context.audioWorklet.addModule('one-pole-processor.js');
+    moduleAdded = true;
+  }
+  
   oscillator = new OscillatorNode(context);
   const filter = new AudioWorkletNode(context, 'one-pole-processor');
   const frequencyParam = filter.parameters.get('frequency');
@@ -38,7 +44,7 @@ window.addEventListener('load', async () => {
   buttonEl.addEventListener('click', async () => {
     if (!isPlaying) { 
       await startAudio(audioContext);
-      audioContext.resume();
+      await audioContext.resume();
       isPlaying = true;
       buttonEl.textContent = 'Playing...'; 
       buttonEl.classList.remove('start-button');

--- a/src/audio-worklet/basic/volume-meter/index.njk
+++ b/src/audio-worklet/basic/volume-meter/index.njk
@@ -21,7 +21,7 @@ to_root_dir: ../../../
     <input id="volume-meter" class="w-full bg-white"
       type="range" min="0" max="100" value="0" step="1" disabled>
   </div>
-  <button id="button-start" disabled>START</button>
+  <button id="button-start" class="start-button">START</button>
   {% include "../../../_includes/example-source-code.njk" %}
 </div>
 

--- a/src/audio-worklet/basic/volume-meter/main.js
+++ b/src/audio-worklet/basic/volume-meter/main.js
@@ -5,9 +5,15 @@
 const audioContext = new AudioContext();
 let mediaStream;
 let volumeMeterNode;
+let moduleAdded = false;
 
 const startAudio = async (context, meterElement) => {
-  await context.audioWorklet.addModule('volume-meter-processor.js');
+
+  if (!moduleAdded) {
+    await context.audioWorklet.addModule('volume-meter-processor.js');
+    moduleAdded = true;
+  }
+  
   mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
   const micNode = context.createMediaStreamSource(mediaStream);
   volumeMeterNode = new AudioWorkletNode(context, 'volume-meter');
@@ -39,7 +45,7 @@ window.addEventListener('load', async () => {
   buttonEl.addEventListener('click', async () => {
     if (!mediaStream) { // If audio is not playing, start audio
       await startAudio(audioContext, meterEl);
-      audioContext.resume();
+      await audioContext.resume();
       buttonEl.textContent = 'STOP';
     } else { // If audio is playing, stop audio
       stopAudio();

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -28,6 +28,11 @@ button[disabled] {
   @apply cursor-not-allowed opacity-50;
 }
 
+/* CSS for stop button */
+#button-start:hover {
+  @apply bg-blue-600 opacity-50;
+}
+
 .inactive {
   @apply fill-blue-400;
 }


### PR DESCRIPTION
The web audio samples lack a stop button functionality, making it difficult for users to pause or stop audio playback once it has started. This limitation hinders the user experience and can be frustrating for individuals testing the demos.

Fix: This PR addresses the issue by implementing a stop button feature in the web audio samples. 

## Changes Made
- Updated `build_info.json` to reflect changes in the project.
- Modified `index.njk` and `main.js` files for several audio worklet demos:
  - `audio-worklet-node-options`: Updated options handling for audio worklet nodes.
  - `hello-audio-worklet`: Improved initialization and error handling.
  - `noise-generator`: Enhanced noise generation functionality.
  - `one-pole-filter`: Refinements to the one-pole filter algorithm.
  - `volume-meter`: Improved volume meter visualization and accuracy.
- Updated `styles.css` for better styling and consistency across demos.

## Purpose
The purpose of this PR is to ensure that the web audio samples provide a smooth and engaging experience for users. By addressing reported bugs and implementing enhancements, we aim to make the demos more useful and accessible to developers interested in web audio technologies.

## Screenshots
![bandicam2024-03-0822-44-52-351-ezgif com-crop](https://github.com/GoogleChromeLabs/web-audio-samples/assets/62840625/68901c39-16fa-47ec-836f-d5e771260e1a)

![bandicam2024-03-0822-45-48-001-ezgif com-crop](https://github.com/GoogleChromeLabs/web-audio-samples/assets/62840625/e39100b6-7087-4951-8ca0-8f3836467f4f)
4-4f8b-4650-bbdf-f652b23fcba0)

