### PR TITLE
Add 4 descriptions to landing page demos

### DIFF
--- a/src/_data/landing_data.yaml
+++ b/src/_data/landing_data.yaml
@@ -40,12 +40,16 @@
       description: For smoke testing
       href: demos/stress-box/
     - title: Wavetable Synthesizer
+      description: Wavetable synthesis and sequencer
       href: demos/wavetable-synth/
     - title: AnalyserNode with visualization 
+      description: Spectrum and waveform visualization with the Canvas API
       href: demos/visualizer/
     - title: Panning and Reverberation
+      description: Spatial and binaural acoustic simulation
       href: demos/panning-reverberation/
     - title: WebGL Pool with 3D audio
+      description: Play pool in your browser
       href: demos/pool/
 
 - title: Selected Projects


### PR DESCRIPTION
Noticed that Wavetable Synthesizer, AnalyserNode with visualization, Panning and Reverberation, and WebGL Pool with 3d audio didn't have descriptions so added them. Perhaps might be more than a non-functional change. 