### PR TITLE
Add listener to wavetable synth for autoplay

### DIFF
--- a/src/demos/wavetable-synth/index.html
+++ b/src/demos/wavetable-synth/index.html
@@ -955,15 +955,29 @@ function addUI() {
 }
 
 function start() {
-    // first, get rid of loading animation
     var loading = document.getElementById("loading");
-    loading.innerHTML = "";
 
-    startTime = context.currentTime + 0.160;
-    
     waveTable = loader.getTable(defaultWaveTableName);
     waveTable2 = loader.getTable(defaultWaveTableName);
-    sequence.schedule();    
+
+    const startAudioPlayback = () => {
+        loading.innerHTML = "";
+        startTime = context.currentTime + 0.160;
+        sequence.schedule();
+    };
+
+    if (context.state === 'running') {
+        startAudioPlayback();
+    } else if (context.state === 'suspended') {
+        loading.innerHTML = "Click anywhere or press a key to start playing.";
+        const interactionHandler = () => {
+            document.removeEventListener('mousedown', interactionHandler);
+            document.removeEventListener('keydown', interactionHandler);
+            context.resume().then(() => startAudioPlayback());
+        };
+        document.addEventListener('mousedown', interactionHandler);
+        document.addEventListener('keydown', interactionHandler);
+    }
 }
 
 </script>


### PR DESCRIPTION
The wavetable synth will not make sound if it is navigated to directly, because there isn't a user gesture so the autoplay rules will be enforced.

This PR adds listeners to allow the user to click or press a key to start playing, even if the page is loaded directly.