### PR TITLE
Add Stop button to AudioWorklet demos missing one

### DIFF
--- a/src/audio-worklet/basic/handling-errors/index.njk
+++ b/src/audio-worklet/basic/handling-errors/index.njk
@@ -20,6 +20,7 @@ to_root_dir: ../../../
 
 <div class="demo-box">
   <button id="button-start" disabled>START</button>
+  <button id="button-stop" disabled>STOP</button>
   {% include "../../../_includes/example-source-code.njk" %}
 </div>
 

--- a/src/audio-worklet/basic/handling-errors/main.js
+++ b/src/audio-worklet/basic/handling-errors/main.js
@@ -3,10 +3,10 @@
 // found in the LICENSE file.
 
 const audioContext = new AudioContext();
+let isModuleLoaded = false;
+let isGraphReady = false;
 
-const startAudio = async (context) => {
-  await context.audioWorklet.addModule('error-processor.js');
-
+const loadGraph = (context) => {
   // To handle an error from the construction phase.
   const constructorErrorWorkletNode =
       new AudioWorkletNode(context, 'constructor-error');
@@ -28,15 +28,36 @@ const startAudio = async (context) => {
   processErrorWorkletNode.connect(context.destination);
 };
 
+const startAudio = async (context) => {
+  if (!isModuleLoaded) {
+    await context.audioWorklet.addModule('error-processor.js');
+    isModuleLoaded = true;
+  }
+  if (!isGraphReady) {
+    loadGraph(context);
+    isGraphReady = true;
+  }
+};
+
 // A simple onLoad handler. It also handles user gesture to unlock the audio
 // playback.
 window.addEventListener('load', async () => {
-  const buttonEl = document.getElementById('button-start');
-  buttonEl.disabled = false;
-  buttonEl.addEventListener('click', async () => {
+  const startButtonEl = document.getElementById('button-start');
+  const stopButtonEl = document.getElementById('button-stop');
+  startButtonEl.disabled = false;
+
+  startButtonEl.addEventListener('click', async () => {
     await startAudio(audioContext);
     audioContext.resume();
-    buttonEl.disabled = true;
-    buttonEl.textContent = 'Playing...';
+    startButtonEl.disabled = true;
+    startButtonEl.textContent = 'Playing...';
+    stopButtonEl.disabled = false;
+  }, false);
+
+  stopButtonEl.addEventListener('click', async () => {
+    audioContext.suspend();
+    startButtonEl.disabled = false;
+    startButtonEl.textContent = 'START';
+    stopButtonEl.disabled = true;
   }, false);
 });

--- a/src/audio-worklet/basic/message-port/index.njk
+++ b/src/audio-worklet/basic/message-port/index.njk
@@ -19,6 +19,7 @@ to_root_dir: ../../../
 
 <div class="demo-box">
   <button id="button-start" disabled>START</button>
+  <button id="button-stop" disabled>STOP</button>
   {% include "../../../_includes/example-source-code.njk" %}
 </div>
 

--- a/src/audio-worklet/basic/message-port/main.js
+++ b/src/audio-worklet/basic/message-port/main.js
@@ -25,25 +25,46 @@ class MessengerWorkletNode extends AudioWorkletNode {
 }
 
 const audioContext = new AudioContext();
+let isModuleLoaded = false;
+let isGraphReady = false;
 
-const startAudio = async (context) => {
-  await context.audioWorklet.addModule('messenger-processor.js');
-
+const loadGraph = (context) => {
   // This worklet node does not need a connection to function. The
   // AudioWorkletNode is automatically processed after construction.
   // eslint-disable-next-line no-unused-vars
   const messengerWorkletNode = new MessengerWorkletNode(context);
 };
 
+const startAudio = async (context) => {
+  if (!isModuleLoaded) {
+    await context.audioWorklet.addModule('messenger-processor.js');
+    isModuleLoaded = true;
+  }
+  if (!isGraphReady) {
+    loadGraph(context);
+    isGraphReady = true;
+  }
+};
+
 // A simple onLoad handler. It also handles user gesture to unlock the audio
 // playback.
 window.addEventListener('load', async () => {
-  const buttonEl = document.getElementById('button-start');
-  buttonEl.disabled = false;
-  buttonEl.addEventListener('click', async () => {
+  const startButtonEl = document.getElementById('button-start');
+  const stopButtonEl = document.getElementById('button-stop');
+  startButtonEl.disabled = false;
+
+  startButtonEl.addEventListener('click', async () => {
     await startAudio(audioContext);
     audioContext.resume();
-    buttonEl.disabled = true;
-    buttonEl.textContent = 'Playing...';
+    startButtonEl.disabled = true;
+    startButtonEl.textContent = 'Playing...';
+    stopButtonEl.disabled = false;
+  }, false);
+
+  stopButtonEl.addEventListener('click', async () => {
+    audioContext.suspend();
+    startButtonEl.disabled = false;
+    startButtonEl.textContent = 'START';
+    stopButtonEl.disabled = true;
   }, false);
 });

--- a/src/audio-worklet/design-pattern/shared-buffer/index.njk
+++ b/src/audio-worklet/design-pattern/shared-buffer/index.njk
@@ -24,6 +24,7 @@ to_root_dir: ../../../
 
 <div class="demo-box">
   <button id="button-start" disabled>START</button>
+  <button id="button-stop" disabled>STOP</button>
   {% include to_root_dir + "_includes/example-source-code.njk" %}
 </div>
 

--- a/src/audio-worklet/design-pattern/shared-buffer/main.js
+++ b/src/audio-worklet/design-pattern/shared-buffer/main.js
@@ -3,14 +3,15 @@
 // found in the LICENSE file.
 
 const audioContext = new AudioContext();
+let isModuleLoaded = false;
+let isGraphReady = false;
 
-const startAudio = async (context) => {
+const loadGraph = async (context) => {
   // Import the pre-defined AudioWorkletNode subclass dynamically. This is
   // invoked only when Audio Worklet is detected.
   const {default: SharedBufferWorkletNode} =
       await import('./shared-buffer-worklet-node.js');
 
-  await context.audioWorklet.addModule('shared-buffer-worklet-processor.js');
   const oscillator = new OscillatorNode(context);
   const sbwNode = new SharedBufferWorkletNode(context);
 
@@ -24,15 +25,36 @@ const startAudio = async (context) => {
   };
 };
 
+const startAudio = async (context) => {
+  if (!isModuleLoaded) {
+    await context.audioWorklet.addModule('shared-buffer-worklet-processor.js');
+    isModuleLoaded = true;
+  }
+  if (!isGraphReady) {
+    await loadGraph(context);
+    isGraphReady = true;
+  }
+};
+
 // A simple onLoad handler. It also handles user gesture to unlock the audio
 // playback.
 window.addEventListener('load', async () => {
-  const buttonEl = document.getElementById('button-start');
-  buttonEl.disabled = false;
-  buttonEl.addEventListener('click', async () => {
+  const startButtonEl = document.getElementById('button-start');
+  const stopButtonEl = document.getElementById('button-stop');
+  startButtonEl.disabled = false;
+
+  startButtonEl.addEventListener('click', async () => {
     await startAudio(audioContext);
     audioContext.resume();
-    buttonEl.disabled = true;
-    buttonEl.textContent = 'Playing...';
+    startButtonEl.disabled = true;
+    startButtonEl.textContent = 'Playing...';
+    stopButtonEl.disabled = false;
+  }, false);
+
+  stopButtonEl.addEventListener('click', async () => {
+    audioContext.suspend();
+    startButtonEl.disabled = false;
+    startButtonEl.textContent = 'START';
+    stopButtonEl.disabled = true;
   }, false);
 });

--- a/src/audio-worklet/design-pattern/wasm-ring-buffer/index.njk
+++ b/src/audio-worklet/design-pattern/wasm-ring-buffer/index.njk
@@ -21,6 +21,7 @@ to_root_dir: ../../../
 
 <div class="demo-box">
   <button id="button-start" disabled>START</button>
+  <button id="button-stop" disabled>STOP</button>
   {% include to_root_dir + "_includes/example-source-code.njk" %}
 </div>
 

--- a/src/audio-worklet/design-pattern/wasm-ring-buffer/main.js
+++ b/src/audio-worklet/design-pattern/wasm-ring-buffer/main.js
@@ -3,9 +3,10 @@
 // found in the LICENSE file.
 
 const audioContext = new AudioContext();
+let isModuleLoaded = false;
+let isGraphReady = false;
 
-const startAudio = async (context) => {
-  await context.audioWorklet.addModule('ring-buffer-worklet-processor.js');
+const loadGraph = (context) => {
   const oscillator = new OscillatorNode(context);
   const ringBufferWorkletNode =
       new AudioWorkletNode(context, 'ring-buffer-worklet-processor', {
@@ -19,15 +20,36 @@ const startAudio = async (context) => {
   oscillator.start();
 };
 
+const startAudio = async (context) => {
+  if (!isModuleLoaded) {
+    await context.audioWorklet.addModule('ring-buffer-worklet-processor.js');
+    isModuleLoaded = true;
+  }
+  if (!isGraphReady) {
+    loadGraph(context);
+    isGraphReady = true;
+  }
+};
+
 // A simple onLoad handler. It also handles user gesture to unlock the audio
 // playback.
 window.addEventListener('load', async () => {
-  const buttonEl = document.getElementById('button-start');
-  buttonEl.disabled = false;
-  buttonEl.addEventListener('click', async () => {
+  const startButtonEl = document.getElementById('button-start');
+  const stopButtonEl = document.getElementById('button-stop');
+  startButtonEl.disabled = false;
+
+  startButtonEl.addEventListener('click', async () => {
     await startAudio(audioContext);
     audioContext.resume();
-    buttonEl.disabled = true;
-    buttonEl.textContent = 'Playing...';
+    startButtonEl.disabled = true;
+    startButtonEl.textContent = 'Playing...';
+    stopButtonEl.disabled = false;
+  }, false);
+
+  stopButtonEl.addEventListener('click', async () => {
+    audioContext.suspend();
+    startButtonEl.disabled = false;
+    startButtonEl.textContent = 'START';
+    stopButtonEl.disabled = true;
   }, false);
 });

--- a/src/audio-worklet/design-pattern/wasm/index.njk
+++ b/src/audio-worklet/design-pattern/wasm/index.njk
@@ -21,6 +21,7 @@ to_root_dir: ../../../
 
 <div class="demo-box">
   <button id="button-start" disabled>START</button>
+  <button id="button-stop" disabled>STOP</button>
   {% include to_root_dir + "_includes/example-source-code.njk" %}
 </div>
 

--- a/src/audio-worklet/design-pattern/wasm/main.js
+++ b/src/audio-worklet/design-pattern/wasm/main.js
@@ -3,24 +3,46 @@
 // found in the LICENSE file.
 
 const audioContext = new AudioContext();
+let isModuleLoaded = false;
+let isGraphReady = false;
 
-const startAudio = async (context) => {
-  await context.audioWorklet.addModule('wasm-worklet-processor.js');
+const loadGraph = (context) => {
   const oscillator = new OscillatorNode(context);
   const bypasser = new AudioWorkletNode(context, 'wasm-worklet-processor');
   oscillator.connect(bypasser).connect(context.destination);
   oscillator.start();
 };
 
+const startAudio = async (context) => {
+  if (!isModuleLoaded) {
+    await context.audioWorklet.addModule('wasm-worklet-processor.js');
+    isModuleLoaded = true;
+  }
+  if (!isGraphReady) {
+    loadGraph(context);
+    isGraphReady = true;
+  }
+};
+
 // A simple onLoad handler. It also handles user gesture to unlock the audio
 // playback.
 window.addEventListener('load', async () => {
-  const buttonEl = document.getElementById('button-start');
-  buttonEl.disabled = false;
-  buttonEl.addEventListener('click', async () => {
+  const startButtonEl = document.getElementById('button-start');
+  const stopButtonEl = document.getElementById('button-stop');
+  startButtonEl.disabled = false;
+
+  startButtonEl.addEventListener('click', async () => {
     await startAudio(audioContext);
     audioContext.resume();
-    buttonEl.disabled = true;
-    buttonEl.textContent = 'Playing...';
+    startButtonEl.disabled = true;
+    startButtonEl.textContent = 'Playing...';
+    stopButtonEl.disabled = false;
+  }, false);
+
+  stopButtonEl.addEventListener('click', async () => {
+    audioContext.suspend();
+    startButtonEl.disabled = false;
+    startButtonEl.textContent = 'START';
+    stopButtonEl.disabled = true;
   }, false);
 });


### PR DESCRIPTION
Several AudioWorklet demos only provide a **START** button, with no way to stop playback without reloading the page.

Add a visible **STOP** button to the affected demos. The button should suspend the audio context and re-enable **START**. Also guard worklet loading and graph setup so repeated starts do not rebuild the audio graph.

## Before -
<img width="1205" height="681" alt="image" src="https://github.com/user-attachments/assets/5830d2f2-04df-45b0-8195-030f055f8974" />

## After -
<img width="1106" height="667" alt="image" src="https://github.com/user-attachments/assets/64121b5f-fcfe-4c48-882b-cdaa6b1c6d46" />
Issue-#473 